### PR TITLE
Make render thread sleep when not rendering to reduce cpu load.

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/gl/render/filters/AndroidViewFilterRender.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/render/filters/AndroidViewFilterRender.java
@@ -292,6 +292,14 @@ public class AndroidViewFilterRender extends BaseFilterRender {
             });
           }
         }
+        else {
+          // not rendering, no need to try again immediately
+          try {
+            Thread.sleep(10);
+          } catch (InterruptedException e) {
+
+          }
+        }
       }
     });
   }


### PR DESCRIPTION
When an AndroidViewFilter is used, the application uses all the cpu cycles it can, because it renders in a busy loop.
This commit introduces a short sleep when the view does not need to be rendered. 
It would be better to communicate between the main thread and the view rendering thread: to make the view rendering thread wait until it gets notified by the main thread when it is done drawing the frame, and needs another frame. However, this works well enough and requires only a very minor change.