### PR TITLE
Fix setLimitFPSOnFly method

### DIFF
--- a/library/src/main/java/com/pedro/library/base/Camera1Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera1Base.java
@@ -909,6 +909,9 @@ public abstract class Camera1Base {
    */
   public void setLimitFPSOnFly(int fps) {
     videoEncoder.setFps(fps);
+    if (glInterface != null) {
+      glInterface.setFps(fps);
+    }
   }
 
   /**

--- a/library/src/main/java/com/pedro/library/base/Camera2Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera2Base.java
@@ -954,6 +954,9 @@ public abstract class Camera2Base {
    */
   public void setLimitFPSOnFly(int fps) {
     videoEncoder.setFps(fps);
+    if (glInterface != null) {
+      glInterface.setFps(fps);
+    }
   }
 
   /**

--- a/library/src/main/java/com/pedro/library/base/DisplayBase.java
+++ b/library/src/main/java/com/pedro/library/base/DisplayBase.java
@@ -526,6 +526,9 @@ public abstract class DisplayBase {
    */
   public void setLimitFPSOnFly(int fps) {
     videoEncoder.setFps(fps);
+    if (glInterface != null) {
+      glInterface.setFps(fps);
+    }
   }
 
   /**

--- a/library/src/main/java/com/pedro/library/base/FromFileBase.java
+++ b/library/src/main/java/com/pedro/library/base/FromFileBase.java
@@ -533,6 +533,9 @@ public abstract class FromFileBase {
    */
   public void setLimitFPSOnFly(int fps) {
     videoEncoder.setFps(fps);
+    if (glInterface != null) {
+      glInterface.setFps(fps);
+    }
   }
 
   /**


### PR DESCRIPTION
Applying fps to encoder on the fly will not have effect when encoder is already started. Instead fps on the fly should be set to intermediate surface i.e. glInterface