### PR TITLE
Allow a custom flashVer string

### DIFF
--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManager.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManager.kt
@@ -49,6 +49,7 @@ abstract class CommandsManager {
   var appName = ""
   var streamName = ""
   var tcUrl = ""
+  var flashVer: String = "FMLE/3.0 (compatible; Lavf57.56.101)"
   var user: String? = null
   var password: String? = null
   var onAuth = false
@@ -83,6 +84,10 @@ abstract class CommandsManager {
   fun setAuth(user: String?, password: String?) {
     this.user = user
     this.password = password
+  }
+
+  fun setFlashVer(flashVer: String) {
+    this.flashVer = flashVer
   }
 
   protected fun getCurrentTimestamp(): Int {

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf0.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf0.kt
@@ -40,7 +40,7 @@ class CommandsManagerAmf0: CommandsManager() {
         BasicHeader(ChunkType.TYPE_0, ChunkStreamId.OVER_CONNECTION.mark))
     val connectInfo = AmfObject()
     connectInfo.setProperty("app", appName + auth)
-    connectInfo.setProperty("flashVer", "FMLE/3.0 (compatible; Lavf57.56.101)")
+    connectInfo.setProperty("flashVer", flashVer)
     connectInfo.setProperty("tcUrl", tcUrl + auth)
     if (!videoDisabled) {
       if (videoCodec == VideoCodec.H265) {

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf3.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf3.kt
@@ -42,7 +42,7 @@ class CommandsManagerAmf3: CommandsManager() {
         BasicHeader(ChunkType.TYPE_0, ChunkStreamId.OVER_CONNECTION.mark))
     val connectInfo = Amf3Object()
     connectInfo.setProperty("app", appName + auth)
-    connectInfo.setProperty("flashVer", "FMLE/3.0 (compatible; Lavf57.56.101)")
+    connectInfo.setProperty("flashVer", flashVer)
     connectInfo.setProperty("tcUrl", tcUrl + auth)
     if (!videoDisabled) {
       if (videoCodec == VideoCodec.H265) {

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -187,6 +187,10 @@ class RtmpClient(private val connectChecker: ConnectChecker) {
     commandsManager.fps = fps
   }
 
+  fun setFlashVer(flashVer: String) {
+    commandsManager.flashVer = flashVer
+  }
+
   fun connect(url: String?) {
     connect(url, false)
   }


### PR DESCRIPTION
This pull requests allows a user to set the flashVer / User Agent String that is sent when starting an RTMP stream.