### PR TITLE
Add support for custom Mpeg2TsService in SRT streaming

### DIFF
--- a/library/src/main/java/com/pedro/library/srt/SrtStream.kt
+++ b/library/src/main/java/com/pedro/library/srt/SrtStream.kt
@@ -31,6 +31,7 @@ import com.pedro.encoder.input.sources.video.VideoSource
 import com.pedro.library.util.streamclient.SrtStreamClient
 import com.pedro.library.util.streamclient.StreamClientListener
 import com.pedro.srt.srt.SrtClient
+import com.pedro.srt.mpeg2ts.service.Mpeg2TsService
 import java.nio.ByteBuffer
 
 /**
@@ -87,5 +88,15 @@ class SrtStream(
 
   override fun getAudioDataImp(audioBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
     srtClient.sendAudio(audioBuffer, info)
+  }
+
+  /**
+   * Set a custom Mpeg2TsService with specified parameters
+   * Must be called before connecting to the server
+   *
+   * @param customService the custom Mpeg2TsService with desired parameters
+   */
+  fun setMpeg2TsService(customService: Mpeg2TsService) {
+    srtClient.setMpeg2TsService(customService)
   }
 }

--- a/library/src/main/java/com/pedro/library/srt/SrtStream.kt
+++ b/library/src/main/java/com/pedro/library/srt/SrtStream.kt
@@ -31,7 +31,6 @@ import com.pedro.encoder.input.sources.video.VideoSource
 import com.pedro.library.util.streamclient.SrtStreamClient
 import com.pedro.library.util.streamclient.StreamClientListener
 import com.pedro.srt.srt.SrtClient
-import com.pedro.srt.mpeg2ts.service.Mpeg2TsService
 import java.nio.ByteBuffer
 
 /**
@@ -88,15 +87,5 @@ class SrtStream(
 
   override fun getAudioDataImp(audioBuffer: ByteBuffer, info: MediaCodec.BufferInfo) {
     srtClient.sendAudio(audioBuffer, info)
-  }
-
-  /**
-   * Set a custom Mpeg2TsService with specified parameters
-   * Must be called before connecting to the server
-   *
-   * @param customService the custom Mpeg2TsService with desired parameters
-   */
-  fun setMpeg2TsService(customService: Mpeg2TsService) {
-    srtClient.setMpeg2TsService(customService)
   }
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
@@ -19,6 +19,7 @@ package com.pedro.library.util.streamclient
 import com.pedro.common.socket.base.SocketType
 import com.pedro.srt.srt.SrtClient
 import com.pedro.srt.srt.packets.control.handshake.EncryptionType
+import com.pedro.srt.mpeg2ts.service.Mpeg2TsService
 
 /**
  * Created by pedro on 12/10/23.
@@ -139,5 +140,15 @@ class SrtStreamClient(
    */
   override fun setSocketType(type: SocketType) {
     srtClient.socketType = type
+  }
+
+  /**
+   * Set a custom Mpeg2TsService with specified parameters
+   * Must be called before connecting to the server
+   *
+   * @param customService the custom Mpeg2TsService with desired parameters
+   */
+  fun setMpeg2TsService(customService: Mpeg2TsService) {
+    srtClient.setMpeg2TsService(customService)
   }
 }

--- a/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
+++ b/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
@@ -59,6 +59,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
 import java.net.URISyntaxException
 import java.nio.ByteBuffer
+import com.pedro.srt.mpeg2ts.service.Mpeg2TsService
 
 /**
  * Created by pedro on 20/8/23.
@@ -473,4 +474,18 @@ class SrtClient(private val connectChecker: ConnectChecker) {
    * Get the exponential factor used to calculate the bitrate. Default 1f
    */
   fun getBitrateExponentialFactor() = srtSender.getBitrateExponentialFactor()
+
+  /**
+   * Set a custom Mpeg2TsService with specified parameters
+   * Must be called before connect
+   *
+   * @param customService the custom Mpeg2TsService with desired parameters
+   */
+  fun setMpeg2TsService(customService: Mpeg2TsService) {
+    if (!isStreaming) {
+      srtSender.setMpeg2TsService(customService)
+    } else {
+      Log.w(TAG, "Can't set custom Mpeg2TsService while streaming")
+    }
+  }
 }


### PR DESCRIPTION
## Description
This PR adds the ability to set a custom Mpeg2TsService with user-defined parameters for SRT streaming.

## Changes
- Modified `SrtSender` to accept a custom `Mpeg2TsService` instead of always using the default one
- Added method in `SrtClient` to expose this functionality to higher levels
- Added method in `SrtStream` to make it accessible at the application level
- Added proper handling for streaming state and service reset

## Usage example
```kotlin
// Create custom service
val customService = Mpeg2TsService(
    type = 0x01, // Digital TV or custom type
    id = 0x1234, // Custom service ID
    name = "MyCustomService", // Custom service name
    providerName = "MyProvider" // Custom provider name
)

// Set it before streaming starts
srtStream.setMpeg2TsService(customService)
```

## Benefits
- Allows customization of MPEG-TS service parameters
- Provides more flexibility for integration with custom broadcasting systems
- Enables customized service identification in the transport stream