### PR TITLE
add support for custom AMF object in streaming clients

### DIFF
--- a/library/src/main/java/com/pedro/library/base/StreamBase.kt
+++ b/library/src/main/java/com/pedro/library/base/StreamBase.kt
@@ -182,9 +182,11 @@ abstract class StreamBase(
    *
    * Must be called after prepareVideo and prepareAudio
    */
-  fun startStream(endPoint: String) {
+  @JvmOverloads
+  fun startStream(endPoint: String, customAmfObject: Map<String, Any> = emptyMap()) {
     if (isStreaming) throw IllegalStateException("Stream already started, stopStream before startStream again")
     isStreaming = true
+    getStreamClient().setCustomAmfObject(customAmfObject)
     startStreamImp(endPoint)
     if (!isRecording) startSources()
     else requestKeyframe()

--- a/library/src/main/java/com/pedro/library/multiple/MultiStream.kt
+++ b/library/src/main/java/com/pedro/library/multiple/MultiStream.kt
@@ -182,7 +182,7 @@ class MultiStream(
                 break
             }
         }
-        if (shouldStarEncoder) super.startStream("")
+        if (shouldStarEncoder) super.startStream("", emptyMap())
         when (type) {
             MultiType.RTMP -> {
                 val resolution = super.getVideoResolution()

--- a/library/src/main/java/com/pedro/library/util/streamclient/GenericStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/GenericStreamClient.kt
@@ -250,4 +250,8 @@ class GenericStreamClient(
    * Get the exponential factor used to calculate the bitrate. Default 1f
    */
   override fun getBitrateExponentialFactor() = connectedStreamClient?.getBitrateExponentialFactor() ?: 1f
+
+  override fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    rtmpClient.setCustomAmfObject(amfObject)
+  }
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/RtmpStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/RtmpStreamClient.kt
@@ -24,7 +24,7 @@ import javax.net.ssl.TrustManager
  * Created by pedro on 12/10/23.
  */
 class RtmpStreamClient(
-  private val rtmpClient: RtmpClient, 
+  private val rtmpClient: RtmpClient,
   private val streamClientListener: StreamClientListener?
 ): StreamBaseClient() {
 
@@ -174,4 +174,9 @@ class RtmpStreamClient(
   override fun setSocketType(type: SocketType) {
     rtmpClient.socketType = type
   }
+
+  override fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    rtmpClient.setCustomAmfObject(amfObject)
+  }
+
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/RtspStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/RtspStreamClient.kt
@@ -149,4 +149,8 @@ class RtspStreamClient(
   override fun setSocketType(type: SocketType) {
     rtspClient.socketType = type
   }
+
+  override fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    //ignored
+  }
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
@@ -167,4 +167,8 @@ class SrtStreamClient(
    * Packets lost reported by NAK command. Increment each time a NAK is received.
    */
   fun getPacketsLost() = srtClient.packetsLost
+
+  override fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    //ignored
+  }
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/StreamBaseClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/StreamBaseClient.kt
@@ -84,4 +84,10 @@ abstract class StreamBaseClient {
    * This will create a cache and wait the delay to start send packets in real time
    */
   abstract fun setDelay(millis: Long)
+
+  /**
+   * Set a custom AMF object to be used in the stream.
+   * @param amfObject The AMF object represented as a Map.
+   */
+  abstract fun setCustomAmfObject(amfObject: Map<String, Any>)
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/UdpStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/UdpStreamClient.kt
@@ -40,6 +40,10 @@ class UdpStreamClient(
     udpClient.setDelay(millis)
   }
 
+  override fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    //ignored
+  }
+
   override fun setReTries(reTries: Int) {
     udpClient.setReTries(reTries)
   }

--- a/rtmp/src/main/java/com/pedro/rtmp/amf/v0/AmfObject.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/amf/v0/AmfObject.kt
@@ -88,6 +88,31 @@ open class AmfObject(private val properties: LinkedHashMap<AmfString, AmfData> =
     bodySize += data.getSize() + 1
   }
 
+  open fun setProperty(name: String, data: Any) {
+    val newValue: AmfData = when (data) {
+      is String   -> AmfString(data)
+      is Int      -> AmfNumber(data.toDouble())
+      is Double   -> AmfNumber(data)
+      is Float    -> AmfNumber(data.toDouble())
+      is Boolean  -> AmfBoolean(data)
+      is AmfData  -> data
+      else        -> throw IllegalArgumentException(
+        "Unsupported value type: ${data::class.java.name}"
+      )
+    }
+
+    val existingEntry = properties.entries.find { it.key.value == name }
+
+    if (existingEntry != null) {
+      properties[existingEntry.key] = newValue
+      bodySize += newValue.getSize() - existingEntry.value.getSize()
+    } else {
+      val key = AmfString(name)
+      properties[key] = newValue
+      bodySize += key.getSize() + newValue.getSize() + 1
+    }
+  }
+
   fun getProperties() = properties
 
   @Throws(IOException::class)

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManager.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManager.kt
@@ -61,6 +61,7 @@ abstract class CommandsManager {
   var readChunkSize = RtmpConfig.DEFAULT_CHUNK_SIZE
   var audioDisabled = false
   var videoDisabled = false
+  var customAmfObject: Map<String, Any> = emptyMap()
   private var bytesRead = 0
   private var acknowledgementSequence = 0
 

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf0.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/CommandsManagerAmf0.kt
@@ -56,6 +56,12 @@ class CommandsManagerAmf0: CommandsManager() {
       }
     }
     connectInfo.setProperty("objectEncoding", 0.0)
+    Log.i(TAG, "customAmfObject0 $customAmfObject")
+    customAmfObject.forEach { (key, value) ->
+      connectInfo.setProperty(key, value)
+    }
+    Log.i(TAG, "connectInfo $connectInfo")
+    Log.i(TAG, "customAmfObject $customAmfObject")
     connect.addData(connectInfo)
 
     connect.writeHeader(socket)

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -175,6 +175,10 @@ class RtmpClient(private val connectChecker: ConnectChecker) {
     }
   }
 
+  fun setCustomAmfObject(amfObject: Map<String, Any>) {
+    commandsManager.customAmfObject = amfObject
+  }
+
   fun setAuthorization(user: String?, password: String?) {
     commandsManager.setAuth(user, password)
   }
@@ -253,7 +257,8 @@ class RtmpClient(private val connectChecker: ConnectChecker) {
         commandsManager.port = urlParser.port ?: defaultPort
         commandsManager.appName = urlParser.getAppName()
         commandsManager.streamName = urlParser.getStreamName()
-        commandsManager.tcUrl = urlParser.getTcUrl()
+        val customTcUrl = commandsManager.customAmfObject["tcUrl"] as? String
+        commandsManager.tcUrl = customTcUrl ?: urlParser.getTcUrl()
         if (commandsManager.appName.isEmpty()) {
           isStreaming = false
           onMainThread {


### PR DESCRIPTION
Summary
This PR adds an optional custom AMF object that is injected during the RTMP connect handshake. It’s designed for large CDN deployments to run targeted stream connectivity checks and diagnostics against specific IPs/nodes by tagging probe metadata in the handshake. Non-RTMP clients safely ignore this parameter.

Changes
	•	Add customAmfObject to StreamBase.startStream(...) and propagate to clients.
	•	RTMP: RtmpClient/CommandsManager merge the custom AMF into the connect object (supports optional tcUrl override).
	•	AmfObject supports dynamic properties.
	•	MultiStream updated; RTSP/SRT/UDP are no-ops.

Compatibility
	•	Backward-compatible: when customAmfObject is null, behavior is unchanged; non-RTMP paths ignore it.