### PR TITLE
Fix for new resolution ratios

### DIFF
--- a/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
+++ b/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
@@ -83,9 +83,9 @@ class CameraFragment: Fragment(), ConnectChecker {
   private lateinit var surfaceView: SurfaceView
   private lateinit var bStartStop: ImageView
   private lateinit var txtBitrate: TextView
-  val width = 640
-  val height = 480
-  val vBitrate = 1200 * 1000
+  val width = 1920
+  val height = 1080
+  val vBitrate = 5 * 1024 * 1024
   private var rotation = 0
   private val sampleRate = 32000
   private val isStereo = true


### PR DESCRIPTION
On modern devices, this is the correct aspect ratio. Using the old ratios (like 640x480) causes image distortion — it results in a stretched or skewed video stream.