### PR TITLE
Add custom onCaptureCompleted callback to expose realtime camera metadata (ISO, WB, Exposure…)

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/sources/video/Camera2Source.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/sources/video/Camera2Source.kt
@@ -18,9 +18,11 @@ package com.pedro.encoder.input.sources.video
 
 import android.content.Context
 import android.graphics.SurfaceTexture
+import android.hardware.camera2.CameraCaptureSession
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraManager
 import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.TotalCaptureResult
 import android.os.Build
 import android.util.Range
 import android.util.Size
@@ -311,5 +313,11 @@ class Camera2Source(context: Context): VideoSource() {
    */
   fun setCustomRequest(request: (CaptureRequest.Builder) -> Unit): Boolean {
     return camera.setCustomRequest(request)
+  }
+
+  fun setCustomOnCaptureCompletedCallback(
+    callback: ((CameraCaptureSession, CaptureRequest, TotalCaptureResult) -> Unit)?
+  ) {
+    camera.setCustomOnCaptureCompletedCallback(callback)
   }
 }


### PR DESCRIPTION
This PR adds a new API that allows clients to register a custom onCaptureCompleted callback and receive realtime CaptureResult metadata from Camera2. This enables external access to parameters such as ISO, white balance, exposure time, focus distance, and other camera settings for each captured frame.