### PR TITLE
Fix UrlParser for encoded url queries

### DIFF
--- a/common/src/main/java/com/pedro/common/UrlParser.kt
+++ b/common/src/main/java/com/pedro/common/UrlParser.kt
@@ -48,8 +48,8 @@ class UrlParser private constructor(
     port = if (uri.port < 0) null else uri.port
     path = uri.path.removePrefix("/")
     if (uri.query != null) {
-      val i = url.indexOf(uri.query)
-      query = url.substring(if (i < 0) 0 else i)
+      val i = url.indexOf("?")
+      query = url.substring(i + 1)
     }
     auth = uri.userInfo
   }

--- a/common/src/test/java/com/pedro/common/UrlParserTest.kt
+++ b/common/src/test/java/com/pedro/common/UrlParserTest.kt
@@ -122,6 +122,15 @@ class UrlParserTest {
       assertEquals("live/test?asd", urlParser9.getAppName())
       assertEquals("asd/streamName", urlParser9.getStreamName())
       assertEquals("rtmp://192.168.0.1:1935/live/test?asd", urlParser9.getTcUrl())
+
+      val url10 = "rtmps://192.168.0.1:1935/live/streamName?queryParam1=value1&queryParam2=YudWE%3d"
+      val urlParser10 = UrlParser.parse(url10, arrayOf("rtmps"))
+      assertEquals("rtmps", urlParser10.scheme)
+      assertEquals("192.168.0.1", urlParser10.host)
+      assertEquals(1935, urlParser10.port)
+      assertEquals("live", urlParser10.getAppName())
+      assertEquals("streamName?queryParam1=value1&queryParam2=YudWE%3d", urlParser10.getStreamName())
+      assertEquals("rtmps://192.168.0.1:1935/live", urlParser10.getTcUrl())
     } catch (_: URISyntaxException) {
       assert(false)
     }


### PR DESCRIPTION
When the initial url is html-encoded, it becomes decoded after wrapping it to java.net.URI object. This leads to incorrect query determination