### PR TITLE
fix: addresses slow frame emission due to time unit mismatch

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/sources/audio/SilenceAudioSource.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/sources/audio/SilenceAudioSource.kt
@@ -42,7 +42,7 @@ class SilenceAudioSource: AudioSource(), GetMicrophoneData {
 
   override fun create(sampleRate: Int, isStereo: Boolean, echoCanceler: Boolean, noiseSuppressor: Boolean): Boolean {
     val channels = if (isStereo) 2 else 1
-    sleepTime = ((buffer.size.toDouble() / (sampleRate * channels * 2L)) * 1000000L).toLong()
+    sleepTime = ((buffer.size.toDouble() / (sampleRate * channels * 2L)) * 1000L).toLong()
     return true
   }
 


### PR DESCRIPTION
# Description
SilenceAudioSource.create() computes sleepTime in microseconds (* 1_000_000L) but passes it to kotlinx.coroutines.delay(Long), which interprets its argument as milliseconds. As a result the silent PCM frames are emitted ~1000× slower than real time. When used with RTMP ingestors that require an audio track (e.g. YouTube), the muxer holds video waiting on audio-timestamp progression, producing multi-second to multi-minute A/V lag. Changing the multiplier from 1_000_000L to 1_000L makes the cadence match the frame's PCM duration.

# Reproduction
RtmpStream with SilenceAudioSource, stream to YouTube — latency grows unboundedly. With the fix, latency matches a MicrophoneSource stream.