### PR TITLE
fix: only log 'GL already released' in debug builds

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/gl/SurfaceManager.java
+++ b/encoder/src/main/java/com/pedro/encoder/input/gl/SurfaceManager.java
@@ -28,6 +28,7 @@ import android.view.Surface;
 
 import androidx.annotation.RequiresApi;
 
+import com.pedro.encoder.BuildConfig;
 import com.pedro.encoder.utils.gl.GlUtil;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -198,7 +199,7 @@ public class SurfaceManager {
       eglDisplay = EGL14.EGL_NO_DISPLAY;
       eglContext = EGL14.EGL_NO_CONTEXT;
       eglSurface = EGL14.EGL_NO_SURFACE;
-    } else {
+    } else if (BuildConfig.DEBUG) {
       Log.e(TAG, "GL already released");
     }
     isReady.set(false);


### PR DESCRIPTION
`SurfaceManager.release()` logged `"GL already released"` at error level every time it was called on an already-released manager. Since `release()` is commonly invoked idempotently (e.g. double-release during teardown), this produced misleading error-level log noise in production apps.

This change gates that log line behind `BuildConfig.DEBUG` so it only appears during development.