### PR TITLE
fix(whip): support https endpoints with Bearer auth

### DIFF
--- a/whip/src/main/java/com/pedro/whip/WhipClient.kt
+++ b/whip/src/main/java/com/pedro/whip/WhipClient.kt
@@ -45,7 +45,7 @@ class WhipClient(private val connectChecker: ConnectChecker) {
 
     private val TAG = "WhipClient"
 
-    private val validSchemes = arrayOf("http")
+    private val validSchemes = arrayOf("http", "https")
 
     private var scope = CoroutineScope(Dispatchers.IO)
     private var scopeRetry = CoroutineScope(Dispatchers.IO)
@@ -67,6 +67,7 @@ class WhipClient(private val connectChecker: ConnectChecker) {
     private var numRetry = 0
     private var reTries = 0
     private var checkServerAlive = false
+    private var auth: String? = null
     var socketType = SocketType.KTOR
 
     val droppedAudioFrames: Long
@@ -89,7 +90,9 @@ class WhipClient(private val connectChecker: ConnectChecker) {
     }
 
     fun setAuthorization(user: String?, password: String?) {
-        TODO("unimplemented")
+        // WHIP auth is a single Bearer token (no user/realm like RTSP). Take it from
+        // password, falling back to user, to fit the shared setAuthorization(user, password) API.
+        auth = password ?: user
     }
 
     /**
@@ -192,18 +195,19 @@ class WhipClient(private val connectChecker: ConnectChecker) {
                 tlsEnabled = urlParser.scheme.endsWith("s")
                 val host = urlParser.host
                 val port = urlParser.port ?: if (tlsEnabled) 443 else 8889
-                val app = urlParser.getAppName()
-                val streamName = urlParser.getStreamName()
-                if (app.isEmpty()) {
+                // Standard WHIP: the endpoint is the full URL. POST to its path; the Bearer token is
+                // supplied via setAuthorization.
+                val path = urlParser.path.removePrefix("/")
+                if (path.isEmpty()) {
                     isStreaming = false
                     onMainThread {
-                        connectChecker.onConnectionFailed("Endpoint malformed, should be: http://ip:port/appname/streamname")
+                        connectChecker.onConnectionFailed("Endpoint malformed, should be: scheme://host:port/path")
                     }
                     return@launch
                 }
 
                 val error = runCatching {
-                    commandsManager.setUrl(host, port, app, streamName)
+                    commandsManager.setUrl(host, port, path, auth, tlsEnabled)
                     if (!commandsManager.audioDisabled) {
                         whipSender.setAudioInfo(commandsManager.sampleRate, commandsManager.isStereo)
                     }

--- a/whip/src/main/java/com/pedro/whip/webrtc/CommandsManager.kt
+++ b/whip/src/main/java/com/pedro/whip/webrtc/CommandsManager.kt
@@ -38,9 +38,11 @@ class CommandsManager {
         private set
     var port = 0
         private set
-    var app: String? = null
+    var path: String? = null
         private set
-    var streamName: String? = null
+    var token: String? = null
+        private set
+    var tlsEnabled = false
         private set
     var sps: ByteBuffer? = null
         private set
@@ -106,11 +108,12 @@ class CommandsManager {
         this.sampleRate = sampleRate
     }
 
-    fun setUrl(host: String, port: Int, app: String, streamName: String?) {
+    fun setUrl(host: String, port: Int, path: String, token: String?, tlsEnabled: Boolean) {
         this.host = host
         this.port = port
-        this.app = app
-        this.streamName = streamName
+        this.path = path
+        this.token = token
+        this.tlsEnabled = tlsEnabled
     }
 
     fun clear() {
@@ -167,14 +170,13 @@ class CommandsManager {
         )
         this.certificate = certificate
         localSdpInfo = SdpInfo(uFrag, uPass, certificate.fingerprint, listOf())
-        val uri = "http://$host:$port/$app"
-        val path: String? = streamName
+        val uri = "${if (tlsEnabled) "https" else "http"}://$host:$port/$path"
         val headers = mutableMapOf<String, String>().apply {
             put("Content-Type", "application/sdp")
-            if (path != null) put("Authorization", "Bearer $path")
+            if (token != null) put("Authorization", "Bearer $token")
         }
         val answer = Requests.makeRequest(
-            uri, "POST", headers, body, timeout, false
+            uri, "POST", headers, body, timeout, tlsEnabled
         )
         remoteSdpInfo = SdpParser.parseBodyAnswer(answer.body)
         tieBreak = secureRandom.nextBytes(8)


### PR DESCRIPTION
`WhipClient` can't publish to https WHIP servers:

- `validSchemes` only allows `"http"`, so an `https://` URL is rejected with *"Endpoint malformed"*.
- `setAuthorization` is an unimplemented `TODO()` that crashes any caller.
- the signaling request hardcodes `http://` and POSTs to only the `appName` path segment, using the last path segment as the token. Standard WHIP servers expect a POST to the **full endpoint URL** with an `Authorization: Bearer` token.

### Changes
- accept `"https"` in `validSchemes`
- build the signaling POST from the parsed scheme (https over TLS) and the full endpoint path
- implement `setAuthorization` to carry the Bearer token (mapped from the shared `user`/`password` API)

Tested against a standard https WHIP ingest (Dolby/Millicast): the publish is accepted (`201` + ICE) where it was previously rejected with *"Endpoint malformed"*.
