### PR TITLE
Treat a single-segment RTMP path with a query as having no app name

### DIFF
--- a/common/src/main/java/com/pedro/common/UrlParser.kt
+++ b/common/src/main/java/com/pedro/common/UrlParser.kt
@@ -70,11 +70,19 @@ class UrlParser private constructor(
     val queries = getAllQueries().map { (key, value) -> "$key=$value" }.joinToString("&")
     val path = getFullPath().ifEmpty { query ?: "" }.replace(queries, "")
     val segments = path.split('/').filter { it.isNotEmpty() }
-    return when(segments.size) {
+    val appName = when(segments.size) {
       0 -> ""
       1, 2 -> segments[0]
       else -> segments.subList(0, 2).joinToString("/")
     }
+    // Removing the query from a single segment leaves a trailing "?", as in
+    // rtmp://host/mystream?user=a&pass=b. Such a URL has no application name:
+    // the whole tail is the stream name, which is what servers reading
+    // credentials from the query expect — the same split OBS makes with
+    // Server "rtmp://host" and Key "mystream?user=a&pass=b". Returning
+    // "mystream?" instead sends the credentials as part of the stream name,
+    // where the server never finds them.
+    return if (appName.endsWith("?")) "" else appName
   }
 
   fun getStreamName(): String = getFullPath().removePrefix(getAppName()).removePrefix("/").removePrefix("?")

--- a/common/src/test/java/com/pedro/common/UrlParserTest.kt
+++ b/common/src/test/java/com/pedro/common/UrlParserTest.kt
@@ -137,6 +137,17 @@ class UrlParserTest {
   }
 
   @Test
+  fun testRtmpUrlWithoutAppName() {
+    // No application name, credentials in the query. Equivalent to OBS with
+    // Server "rtmp://192.168.0.1:1935" and Key "streamName?user=a&pass=b".
+    val url = "rtmp://192.168.0.1:1935/streamName?user=a&pass=b"
+    val urlParser = UrlParser.parse(url, arrayOf("rtmp"))
+    assertEquals("", urlParser.getAppName())
+    assertEquals("streamName?user=a&pass=b", urlParser.getStreamName())
+    assertEquals("rtmp://192.168.0.1:1935", urlParser.getTcUrl())
+  }
+
+  @Test
   fun testRtspUrls() {
     try {
       val url = "rtsp://localhost:1935/live?test/fake"

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -273,7 +273,7 @@ class RtmpClient(private val connectChecker: ConnectChecker) {
         commandsManager.appName = urlParser.getAppName()
         commandsManager.streamName = urlParser.getStreamName()
         commandsManager.tcUrl = urlParser.getTcUrl()
-        if (commandsManager.appName.isEmpty()) {
+        if (commandsManager.appName.isEmpty() && commandsManager.streamName.isEmpty()) {
           isStreaming = false
           onMainThread {
             connectChecker.onConnectionFailed(


### PR DESCRIPTION
### Problem

RootEncoder can't publish to an RTMP URL whose path is a single segment carrying a
query string:

```
rtmp://host/mystream?user=alice&pass=secret
```

`UrlParser.getAppName()` builds the app name by removing the query from the full path.
With one segment that leaves a trailing `?`, so the URL resolves to:

| | value |
|---|---|
| appName | `mystream?` |
| streamName | `user=alice&pass=secret` |
| tcUrl | `rtmp://host/mystream?` |

The credentials stop being a query and become the stream *name*, so a server that reads
them from the query never sees them and refuses the publish. The app name is also wrong.

This is the URL format MediaMTX documents for authenticated publishing, and the only one
it supports — passing credentials as `rtmp://user:pass@host` was declined in
bluenviron/mediamtx#1070. It is the same split OBS makes with Server `rtmp://host` and
Stream Key `mystream?user=alice&pass=secret`.

### Fix

Such a URL has no application name: the whole tail is the stream name. `getAppName()`
now returns an empty string when the computed name ends in `?`, and `RtmpClient` accepts
an empty app name as long as a stream name is present.

`getStreamName()` is unchanged — with the app name empty it already returns the full
tail, query included.

### Scope

Only the trailing-`?` case changes. That trailing `?` appears solely when the query
parsed into `k=v` pairs and was stripped from a single segment, so every other shape is
untouched:

| URL path | appName | streamName | changed |
|---|---|---|---|
| `/mystream?user=a&pass=b` | `""` (was `mystream?`) | `mystream?user=a&pass=b` | yes |
| `/live` | `live` | `""` | no |
| `/live/` | `live` | `""` | no |
| `?live` | `live` | `""` | no |
| `/live?test/fake` | `live?test` | `fake` | no |
| `/live/test` | `live` | `test` | no |
| `/live/100044?userId=100044&…` | `live` | `100044?userId=100044&…` | no |
| `/v2/pub/streamName?token=…` | `v2/pub` | `streamName?token=…` | no |
| `/live/test/fake` | `live/test` | `fake` | no |

### Testing

- All existing `UrlParserTest` cases pass unchanged.
- Added `testRtmpUrlWithoutAppName` covering the URL above.
- Verified end to end against MediaMTX over RTMPS from an Android device: the publish
  authenticates and the stream plays. It failed with `failed to authenticate` before.

### Notes

Happy to adjust the approach. An alternative would be leaving `getAppName()` alone and
handling the empty-app case in `RtmpClient`, but the trailing `?` looked like a parsing
bug rather than something callers should work around.