### PR TITLE
Add streaming stats callback with byte-accurate queue monitoring

### DIFF
--- a/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
+++ b/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
@@ -230,7 +230,7 @@ class CameraFragment: Fragment(), ConnectChecker {
 
   override fun onStreamingStats(report: StreamingStatsReport) {
     onMainThreadHandler {
-      if (report.throughput != Throughput.Unknown) {
+      if (report.throughput != Throughput.UNKNOWN) {
         txtBitrate.text = String.format(
           Locale.getDefault(),
           "%.1f mb/s [%s, queue %d KB]",

--- a/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
+++ b/app/src/main/java/com/pedro/streamer/rotation/CameraFragment.kt
@@ -30,6 +30,8 @@ import android.widget.TextView
 import androidx.annotation.RequiresApi
 import androidx.fragment.app.Fragment
 import com.pedro.common.ConnectChecker
+import com.pedro.common.StreamingStatsReport
+import com.pedro.common.Throughput
 import com.pedro.common.onMainThreadHandler
 import com.pedro.encoder.input.sources.video.Camera1Source
 import com.pedro.encoder.input.sources.video.Camera2Source
@@ -223,6 +225,20 @@ class CameraFragment: Fragment(), ConnectChecker {
     onMainThreadHandler {
       bitrateAdapter.adaptBitrate(bitrate, genericStream.getStreamClient().hasCongestion())
       txtBitrate.text = String.format(Locale.getDefault(), "%.1f mb/s", bitrate / 1000_000f)
+    }
+  }
+
+  override fun onStreamingStats(report: StreamingStatsReport) {
+    onMainThreadHandler {
+      if (report.throughput != Throughput.Unknown) {
+        txtBitrate.text = String.format(
+          Locale.getDefault(),
+          "%.1f mb/s [%s, queue %d KB]",
+          report.smoothedBitrate / 1000_000f,
+          report.throughput.name.lowercase(),
+          report.queueBytesOut / 1024,
+        )
+      }
     }
   }
 

--- a/common/src/main/java/com/pedro/common/BitrateManager.kt
+++ b/common/src/main/java/com/pedro/common/BitrateManager.kt
@@ -43,6 +43,8 @@ open class BitrateManager(private val bitrateChecker: BitrateChecker) {
     }
   }
 
+  fun getSmoothedBitrate(): Long = bitrateOld
+
   fun reset() {
     bitrate = 0
     bitrateOld = 0

--- a/common/src/main/java/com/pedro/common/StreamBlockingQueue.kt
+++ b/common/src/main/java/com/pedro/common/StreamBlockingQueue.kt
@@ -72,4 +72,10 @@ class StreamBlockingQueue(var capacity: Int) {
     }
 
     fun getSize() = queue.size
+
+    /**
+     * Sum of [MediaFrame.info.size] for all frames in the main send queue.
+     * Delay/cache queue bytes are excluded.
+     */
+    fun getTotalSize(): Long = queue.sumOf { it.info.size.toLong() }
 }

--- a/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
@@ -35,7 +35,7 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
     totalBytesOut: Long,
     smoothedBitrate: Long,
   ) {
-    var throughput = Throughput.Unknown
+    var throughput = Throughput.UNKNOWN
     previousQueueBytesOut.add(queueBytesOut)
     if (measureInterval <= previousQueueBytesOut.size) {
       var countQueuedBytesGrowing = 0
@@ -45,9 +45,9 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
         }
       }
       if (countQueuedBytesGrowing == measureInterval - 1) {
-        throughput = Throughput.Insufficient
+        throughput = Throughput.INSUFFICIENT
       } else if (countQueuedBytesGrowing == 0) {
-        throughput = Throughput.Sufficient
+        throughput = Throughput.SUFFICIENT
       }
       previousQueueBytesOut.removeAt(0)
     }

--- a/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
@@ -23,6 +23,7 @@ package com.pedro.common
 class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
 
   private val measureInterval = 3
+  private val congestionThreshold = 95f
   private val previousQueueBytesOut: MutableList<Long> = mutableListOf()
 
   fun reset() {
@@ -34,7 +35,7 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
     bytesOutPerSecond: Long,
     totalBytesOut: Long,
     smoothedBitrate: Long,
-    queueCongested: Boolean,
+    queueCongestionPercent: Float,
   ) {
     var throughput = Throughput.UNKNOWN
     previousQueueBytesOut.add(queueBytesOut)
@@ -54,7 +55,7 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
     }
     // This library caps the queue at a fixed capacity,
     // so a saturated queue stops growing and will return Insufficient
-    if (queueCongested) {
+    if (queueCongestionPercent >= congestionThreshold) {
       throughput = Throughput.INSUFFICIENT
     }
 
@@ -62,6 +63,7 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
       bytesOutPerSecond = bytesOutPerSecond,
       queueBytesOut = queueBytesOut,
       totalBytesOut = totalBytesOut,
+      queueCongestionPercent = queueCongestionPercent,
       throughput = throughput,
       bitrate = bytesOutPerSecond * 8,
       smoothedBitrate = smoothedBitrate,

--- a/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
@@ -34,6 +34,7 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
     bytesOutPerSecond: Long,
     totalBytesOut: Long,
     smoothedBitrate: Long,
+    queueCongested: Boolean,
   ) {
     var throughput = Throughput.UNKNOWN
     previousQueueBytesOut.add(queueBytesOut)
@@ -50,6 +51,11 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
         throughput = Throughput.SUFFICIENT
       }
       previousQueueBytesOut.removeAt(0)
+    }
+    // This library caps the queue at a fixed capacity,
+    // so a saturated queue stops growing and will return Insufficient
+    if (queueCongested) {
+      throughput = Throughput.INSUFFICIENT
     }
 
     val report = StreamingStatsReport(

--- a/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2024 pedroSG94.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pedro.common
+
+/**
+ * Collects send-queue and throughput statistics each second and classifies bandwidth trends
+ * over a sliding window, mirroring HaishinKit NetworkMonitor behavior.
+ */
+class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
+
+  private val measureInterval = 3
+  private val previousQueueBytesOut: MutableList<Long> = mutableListOf()
+  private var previousTotalBytesIn = 0L
+
+  fun reset() {
+    previousQueueBytesOut.clear()
+    previousTotalBytesIn = 0L
+  }
+
+  suspend fun collect(
+    queueBytesOut: Long,
+    bytesOutPerSecond: Long,
+    totalBytesOut: Long,
+    totalBytesIn: Long,
+    smoothedBitrate: Long,
+  ) {
+    val bytesInPerSecond = totalBytesIn - previousTotalBytesIn
+    previousTotalBytesIn = totalBytesIn
+
+    var throughput = Throughput.Unknown
+    previousQueueBytesOut.add(queueBytesOut)
+    if (measureInterval <= previousQueueBytesOut.size) {
+      var countQueuedBytesGrowing = 0
+      for (i in 0 until previousQueueBytesOut.size - 1) {
+        if (previousQueueBytesOut[i] < previousQueueBytesOut[i + 1]) {
+          countQueuedBytesGrowing++
+        }
+      }
+      if (countQueuedBytesGrowing == measureInterval - 1) {
+        throughput = Throughput.Insufficient
+      } else if (countQueuedBytesGrowing == 0) {
+        throughput = Throughput.Sufficient
+      }
+      previousQueueBytesOut.removeAt(0)
+    }
+
+    val report = StreamingStatsReport(
+      bytesOutPerSecond = bytesOutPerSecond,
+      queueBytesOut = queueBytesOut,
+      totalBytesOut = totalBytesOut,
+      totalBytesIn = totalBytesIn,
+      bytesInPerSecond = bytesInPerSecond,
+      throughput = throughput,
+      bitrate = bytesOutPerSecond * 8,
+      smoothedBitrate = smoothedBitrate,
+    )
+    onMainThread { bitrateChecker.onStreamingStats(report) }
+  }
+}

--- a/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsMonitor.kt
@@ -24,23 +24,17 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
 
   private val measureInterval = 3
   private val previousQueueBytesOut: MutableList<Long> = mutableListOf()
-  private var previousTotalBytesIn = 0L
 
   fun reset() {
     previousQueueBytesOut.clear()
-    previousTotalBytesIn = 0L
   }
 
   suspend fun collect(
     queueBytesOut: Long,
     bytesOutPerSecond: Long,
     totalBytesOut: Long,
-    totalBytesIn: Long,
     smoothedBitrate: Long,
   ) {
-    val bytesInPerSecond = totalBytesIn - previousTotalBytesIn
-    previousTotalBytesIn = totalBytesIn
-
     var throughput = Throughput.Unknown
     previousQueueBytesOut.add(queueBytesOut)
     if (measureInterval <= previousQueueBytesOut.size) {
@@ -62,8 +56,6 @@ class StreamingStatsMonitor(private val bitrateChecker: BitrateChecker) {
       bytesOutPerSecond = bytesOutPerSecond,
       queueBytesOut = queueBytesOut,
       totalBytesOut = totalBytesOut,
-      totalBytesIn = totalBytesIn,
-      bytesInPerSecond = bytesInPerSecond,
       throughput = throughput,
       bitrate = bytesOutPerSecond * 8,
       smoothedBitrate = smoothedBitrate,

--- a/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
@@ -25,6 +25,8 @@ data class StreamingStatsReport(
   val bytesOutPerSecond: Long,
   val queueBytesOut: Long,
   val totalBytesOut: Long,
+  /** Percent (0-100) of the send queue's fixed capacity currently in use. */
+  val queueCongestionPercent: Float,
   val throughput: Throughput,
   val bitrate: Long,
   val smoothedBitrate: Long,

--- a/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
@@ -25,8 +25,6 @@ data class StreamingStatsReport(
   val bytesOutPerSecond: Long,
   val queueBytesOut: Long,
   val totalBytesOut: Long,
-  val totalBytesIn: Long = 0,
-  val bytesInPerSecond: Long = 0,
   val throughput: Throughput,
   val bitrate: Long,
   val smoothedBitrate: Long,

--- a/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
+++ b/common/src/main/java/com/pedro/common/StreamingStatsReport.kt
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-package com.pedro.common;
+package com.pedro.common
 
 /**
- * Created by pedro on 30/5/24.
+ * Per-second streaming statistics report.
+ *
+ * Mirrors HaishinKit [NetworkMonitorReport](https://github.com/HaishinKit/HaishinKit.swift/blob/main/HaishinKit/Sources/Network/NetworkMonitorReport.swift).
  */
-public interface BitrateChecker {
-  default void onNewBitrate(long bitrate) {}
-
-  default void onStreamingStats(StreamingStatsReport report) {}
-}
+data class StreamingStatsReport(
+  val bytesOutPerSecond: Long,
+  val queueBytesOut: Long,
+  val totalBytesOut: Long,
+  val totalBytesIn: Long = 0,
+  val bytesInPerSecond: Long = 0,
+  val throughput: Throughput,
+  val bitrate: Long,
+  val smoothedBitrate: Long,
+)

--- a/common/src/main/java/com/pedro/common/Throughput.kt
+++ b/common/src/main/java/com/pedro/common/Throughput.kt
@@ -14,13 +14,10 @@
  * limitations under the License.
  */
 
-package com.pedro.common;
+package com.pedro.common
 
-/**
- * Created by pedro on 30/5/24.
- */
-public interface BitrateChecker {
-  default void onNewBitrate(long bitrate) {}
-
-  default void onStreamingStats(StreamingStatsReport report) {}
+enum class Throughput {
+  Unknown,
+  Sufficient,
+  Insufficient,
 }

--- a/common/src/main/java/com/pedro/common/Throughput.kt
+++ b/common/src/main/java/com/pedro/common/Throughput.kt
@@ -17,7 +17,7 @@
 package com.pedro.common
 
 enum class Throughput {
-  Unknown,
-  Sufficient,
-  Insufficient,
+  UNKNOWN,
+  SUFFICIENT,
+  INSUFFICIENT,
 }

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -8,6 +8,7 @@ import com.pedro.common.StreamBlockingQueue
 import com.pedro.common.clone
 import com.pedro.common.StreamingStatsMonitor
 import com.pedro.common.frame.MediaFrame
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -91,17 +92,25 @@ abstract class BaseSender(
         job = scope.launch {
             val bitrateTask = async {
                 while (scope.isActive && running) {
-                    val bytesThisSecond = bytesSendPerSecond.get()
-                    //bytes to bits
-                    bitrateManager.calculateBitrate(bytesThisSecond * 8)
-                    streamingStatsMonitor.collect(
-                        queueBytesOut = queue.getTotalSize(),
-                        bytesOutPerSecond = bytesThisSecond,
-                        totalBytesOut = bytesSend.get(),
-                        totalBytesIn = 0L,
-                        smoothedBitrate = bitrateManager.getSmoothedBitrate(),
-                    )
-                    bytesSendPerSecond.set(0)
+                    try {
+                        val bytesThisSecond = bytesSendPerSecond.get()
+                        //bytes to bits
+                        bitrateManager.calculateBitrate(bytesThisSecond * 8)
+                        streamingStatsMonitor.collect(
+                            queueBytesOut = queue.getTotalSize(),
+                            bytesOutPerSecond = bytesThisSecond,
+                            totalBytesOut = bytesSend.get(),
+                            totalBytesIn = 0L,
+                            smoothedBitrate = bitrateManager.getSmoothedBitrate(),
+                        )
+                        bytesSendPerSecond.set(0)
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        //never let a reporting failure (e.g. no Main dispatcher, checker callback
+                        //throwing) take down the send loop
+                        Log.e(TAG, "bitrate/stats reporting failed", e)
+                    }
                     delay(timeMillis = 1000)
                 }
             }

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -101,7 +101,7 @@ abstract class BaseSender(
                             bytesOutPerSecond = bytesThisSecond,
                             totalBytesOut = bytesSend.get(),
                             smoothedBitrate = bitrateManager.getSmoothedBitrate(),
-                            queueCongested = hasCongestion(95f),
+                            queueCongestionPercent = queueUsagePercent(),
                         )
                         bytesSendPerSecond.set(0)
                     } catch (e: CancellationException) {
@@ -135,10 +135,14 @@ abstract class BaseSender(
     @Throws(IllegalArgumentException::class)
     fun hasCongestion(percentUsed: Float = 20f): Boolean {
         if (percentUsed !in 0.0..100.0) throw IllegalArgumentException("the value must be in range 0 to 100")
+        return queueUsagePercent() >= percentUsed
+    }
+
+    private fun queueUsagePercent(): Float {
         val size = queue.getSize().toFloat()
         val remaining = queue.remainingCapacity().toFloat()
         val capacity = size + remaining
-        return size >= capacity * (percentUsed / 100f)
+        return if (capacity <= 0f) 0f else (size / capacity) * 100f
     }
 
     fun resizeCache(newSize: Int) {

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -101,6 +101,7 @@ abstract class BaseSender(
                             bytesOutPerSecond = bytesThisSecond,
                             totalBytesOut = bytesSend.get(),
                             smoothedBitrate = bitrateManager.getSmoothedBitrate(),
+                            queueCongested = hasCongestion(95f),
                         )
                         bytesSendPerSecond.set(0)
                     } catch (e: CancellationException) {

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -90,6 +90,7 @@ abstract class BaseSender(
                 while (scope.isActive && running) {
                     //bytes to bits
                     bitrateManager.calculateBitrate(bytesSendPerSecond.get() * 8)
+                    )
                     bytesSendPerSecond.set(0)
                     delay(timeMillis = 1000)
                 }
@@ -131,6 +132,8 @@ abstract class BaseSender(
     fun getCacheSize(): Int = queue.capacity
 
     fun getItemsInCache(): Int = queue.getSize()
+
+    fun getQueueBytesOut(): Long = queue.getTotalSize()
 
     fun clearCache() {
         queue.clear { bufferPool.release(it.data) }

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -100,7 +100,6 @@ abstract class BaseSender(
                             queueBytesOut = queue.getTotalSize(),
                             bytesOutPerSecond = bytesThisSecond,
                             totalBytesOut = bytesSend.get(),
-                            totalBytesIn = 0L,
                             smoothedBitrate = bitrateManager.getSmoothedBitrate(),
                         )
                         bytesSendPerSecond.set(0)

--- a/common/src/main/java/com/pedro/common/base/BaseSender.kt
+++ b/common/src/main/java/com/pedro/common/base/BaseSender.kt
@@ -6,6 +6,7 @@ import com.pedro.common.BufferPool
 import com.pedro.common.ConnectChecker
 import com.pedro.common.StreamBlockingQueue
 import com.pedro.common.clone
+import com.pedro.common.StreamingStatsMonitor
 import com.pedro.common.frame.MediaFrame
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,6 +37,7 @@ abstract class BaseSender(
     private val droppedVideoFrames = AtomicLong(0)
 
     private val bitrateManager: BitrateManager = BitrateManager(connectChecker)
+    private val streamingStatsMonitor: StreamingStatsMonitor = StreamingStatsMonitor(connectChecker)
     protected var isEnableLogs = true
     private var job: Job? = null
     protected val scope = CoroutineScope(Dispatchers.IO)
@@ -84,12 +86,20 @@ abstract class BaseSender(
     fun start() {
         bitrateManager.reset()
         queue.clear { bufferPool.release(it.data) }
+        streamingStatsMonitor.reset()
         running = true
         job = scope.launch {
             val bitrateTask = async {
                 while (scope.isActive && running) {
+                    val bytesThisSecond = bytesSendPerSecond.get()
                     //bytes to bits
-                    bitrateManager.calculateBitrate(bytesSendPerSecond.get() * 8)
+                    bitrateManager.calculateBitrate(bytesThisSecond * 8)
+                    streamingStatsMonitor.collect(
+                        queueBytesOut = queue.getTotalSize(),
+                        bytesOutPerSecond = bytesThisSecond,
+                        totalBytesOut = bytesSend.get(),
+                        totalBytesIn = 0L,
+                        smoothedBitrate = bitrateManager.getSmoothedBitrate(),
                     )
                     bytesSendPerSecond.set(0)
                     delay(timeMillis = 1000)

--- a/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
+++ b/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2024 pedroSG94.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pedro.common
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+
+@RunWith(MockitoJUnitRunner::class)
+class StreamingStatsMonitorTest {
+
+  @OptIn(ExperimentalCoroutinesApi::class)
+  @get:Rule
+  val mainDispatcherRule = object : TestWatcher() {
+    override fun starting(description: Description) {
+      Dispatchers.setMain(UnconfinedTestDispatcher())
+    }
+
+    override fun finished(description: Description) {
+      Dispatchers.resetMain()
+    }
+  }
+
+  @Mock
+  private lateinit var connectChecker: ConnectChecker
+
+  private lateinit var monitor: StreamingStatsMonitor
+
+  @Before
+  fun setup() {
+    monitor = StreamingStatsMonitor(connectChecker)
+  }
+
+  @Test
+  fun `WHEN fewer than 3 samples THEN throughput is Unknown`() = runTest {
+    monitor.collect(
+      queueBytesOut = 100L,
+      bytesOutPerSecond = 1000L,
+      totalBytesOut = 1000L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 8000L,
+    )
+    monitor.collect(
+      queueBytesOut = 200L,
+      bytesOutPerSecond = 1000L,
+      totalBytesOut = 2000L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 8000L,
+    )
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(2)).onStreamingStats(captor.capture())
+    captor.allValues.forEach { assertEquals(Throughput.Unknown, it.throughput) }
+  }
+
+  @Test
+  fun `WHEN queue bytes grow for 3 intervals THEN throughput is Insufficient`() = runTest {
+    repeat(2) {
+      monitor.collect(
+        queueBytesOut = (it + 1) * 100L,
+        bytesOutPerSecond = 500L,
+        totalBytesOut = 500L,
+        totalBytesIn = 0L,
+        smoothedBitrate = 4000L,
+      )
+    }
+    monitor.collect(
+      queueBytesOut = 300L,
+      bytesOutPerSecond = 500L,
+      totalBytesOut = 1500L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 4000L,
+    )
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(3)).onStreamingStats(captor.capture())
+    assertEquals(Throughput.Insufficient, captor.lastValue.throughput)
+    assertEquals(300L, captor.lastValue.queueBytesOut)
+    assertEquals(500L, captor.lastValue.bytesOutPerSecond)
+    assertEquals(4000L, captor.lastValue.bitrate)
+  }
+
+  @Test
+  fun `WHEN queue bytes shrink for 3 intervals THEN throughput is Sufficient`() = runTest {
+    monitor.collect(
+      queueBytesOut = 300L,
+      bytesOutPerSecond = 800L,
+      totalBytesOut = 800L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 6400L,
+    )
+    monitor.collect(
+      queueBytesOut = 200L,
+      bytesOutPerSecond = 800L,
+      totalBytesOut = 1600L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 6400L,
+    )
+    monitor.collect(
+      queueBytesOut = 100L,
+      bytesOutPerSecond = 800L,
+      totalBytesOut = 2400L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 6400L,
+    )
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(3)).onStreamingStats(captor.capture())
+    assertEquals(Throughput.Sufficient, captor.lastValue.throughput)
+  }
+
+  @Test
+  fun `WHEN queue trend is mixed THEN throughput stays Unknown`() = runTest {
+    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, totalBytesIn = 0L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, totalBytesIn = 0L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, totalBytesIn = 0L, smoothedBitrate = 800L)
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(3)).onStreamingStats(captor.capture())
+    assertEquals(Throughput.Unknown, captor.lastValue.throughput)
+  }
+
+  @Test
+  fun `WHEN reset THEN trend window clears`() = runTest {
+    repeat(3) {
+      monitor.collect(
+        queueBytesOut = (it + 1) * 100L,
+        bytesOutPerSecond = 100L,
+        totalBytesOut = 100L,
+        totalBytesIn = 0L,
+        smoothedBitrate = 800L,
+      )
+    }
+    monitor.reset()
+    monitor.collect(
+      queueBytesOut = 400L,
+      bytesOutPerSecond = 100L,
+      totalBytesOut = 100L,
+      totalBytesIn = 0L,
+      smoothedBitrate = 800L,
+    )
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(4)).onStreamingStats(captor.capture())
+    assertEquals(Throughput.Unknown, captor.lastValue.throughput)
+  }
+}

--- a/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
+++ b/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
@@ -67,12 +67,14 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 1000L,
       totalBytesOut = 1000L,
       smoothedBitrate = 8000L,
+      queueCongested = false,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 1000L,
       totalBytesOut = 2000L,
       smoothedBitrate = 8000L,
+      queueCongested = false,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -88,6 +90,7 @@ class StreamingStatsMonitorTest {
         bytesOutPerSecond = 500L,
         totalBytesOut = 500L,
         smoothedBitrate = 4000L,
+        queueCongested = false,
       )
     }
     monitor.collect(
@@ -95,6 +98,7 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 500L,
       totalBytesOut = 1500L,
       smoothedBitrate = 4000L,
+      queueCongested = false,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -112,18 +116,21 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 800L,
       totalBytesOut = 800L,
       smoothedBitrate = 6400L,
+      queueCongested = false,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 1600L,
       smoothedBitrate = 6400L,
+      queueCongested = false,
     )
     monitor.collect(
       queueBytesOut = 100L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 2400L,
       smoothedBitrate = 6400L,
+      queueCongested = false,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -133,9 +140,9 @@ class StreamingStatsMonitorTest {
 
   @Test
   fun `WHEN queue trend is mixed THEN throughput stays Unknown`() = runTest {
-    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, smoothedBitrate = 800L)
-    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, smoothedBitrate = 800L)
-    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, smoothedBitrate = 800L, queueCongested = false)
+    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, smoothedBitrate = 800L, queueCongested = false)
+    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, smoothedBitrate = 800L, queueCongested = false)
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
@@ -150,6 +157,7 @@ class StreamingStatsMonitorTest {
         bytesOutPerSecond = 100L,
         totalBytesOut = 100L,
         smoothedBitrate = 800L,
+        queueCongested = false,
       )
     }
     monitor.reset()
@@ -158,10 +166,30 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 100L,
       totalBytesOut = 100L,
       smoothedBitrate = 800L,
+      queueCongested = false,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(4)).onStreamingStats(captor.capture())
     assertEquals(Throughput.UNKNOWN, captor.lastValue.throughput)
+  }
+
+  @Test
+  fun `WHEN queue is congested THEN throughput is Insufficient even with a flat queue trend`() = runTest {
+    //queueBytesOut stays flat because the queue is saturated at its fixed capacity, not
+    //because throughput is healthy, so the trend alone would misread this as Sufficient
+    repeat(3) {
+      monitor.collect(
+        queueBytesOut = 1000L,
+        bytesOutPerSecond = 100L,
+        totalBytesOut = 100L,
+        smoothedBitrate = 800L,
+        queueCongested = true,
+      )
+    }
+
+    val captor = argumentCaptor<StreamingStatsReport>()
+    verify(connectChecker, times(3)).onStreamingStats(captor.capture())
+    assertEquals(Throughput.INSUFFICIENT, captor.lastValue.throughput)
   }
 }

--- a/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
+++ b/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
@@ -66,14 +66,12 @@ class StreamingStatsMonitorTest {
       queueBytesOut = 100L,
       bytesOutPerSecond = 1000L,
       totalBytesOut = 1000L,
-      totalBytesIn = 0L,
       smoothedBitrate = 8000L,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 1000L,
       totalBytesOut = 2000L,
-      totalBytesIn = 0L,
       smoothedBitrate = 8000L,
     )
 
@@ -89,7 +87,6 @@ class StreamingStatsMonitorTest {
         queueBytesOut = (it + 1) * 100L,
         bytesOutPerSecond = 500L,
         totalBytesOut = 500L,
-        totalBytesIn = 0L,
         smoothedBitrate = 4000L,
       )
     }
@@ -97,7 +94,6 @@ class StreamingStatsMonitorTest {
       queueBytesOut = 300L,
       bytesOutPerSecond = 500L,
       totalBytesOut = 1500L,
-      totalBytesIn = 0L,
       smoothedBitrate = 4000L,
     )
 
@@ -115,21 +111,18 @@ class StreamingStatsMonitorTest {
       queueBytesOut = 300L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 800L,
-      totalBytesIn = 0L,
       smoothedBitrate = 6400L,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 1600L,
-      totalBytesIn = 0L,
       smoothedBitrate = 6400L,
     )
     monitor.collect(
       queueBytesOut = 100L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 2400L,
-      totalBytesIn = 0L,
       smoothedBitrate = 6400L,
     )
 
@@ -140,9 +133,9 @@ class StreamingStatsMonitorTest {
 
   @Test
   fun `WHEN queue trend is mixed THEN throughput stays Unknown`() = runTest {
-    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, totalBytesIn = 0L, smoothedBitrate = 800L)
-    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, totalBytesIn = 0L, smoothedBitrate = 800L)
-    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, totalBytesIn = 0L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, smoothedBitrate = 800L)
+    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, smoothedBitrate = 800L)
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
@@ -156,7 +149,6 @@ class StreamingStatsMonitorTest {
         queueBytesOut = (it + 1) * 100L,
         bytesOutPerSecond = 100L,
         totalBytesOut = 100L,
-        totalBytesIn = 0L,
         smoothedBitrate = 800L,
       )
     }
@@ -165,7 +157,6 @@ class StreamingStatsMonitorTest {
       queueBytesOut = 400L,
       bytesOutPerSecond = 100L,
       totalBytesOut = 100L,
-      totalBytesIn = 0L,
       smoothedBitrate = 800L,
     )
 

--- a/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
+++ b/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
@@ -67,14 +67,14 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 1000L,
       totalBytesOut = 1000L,
       smoothedBitrate = 8000L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 1000L,
       totalBytesOut = 2000L,
       smoothedBitrate = 8000L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -90,7 +90,7 @@ class StreamingStatsMonitorTest {
         bytesOutPerSecond = 500L,
         totalBytesOut = 500L,
         smoothedBitrate = 4000L,
-        queueCongested = false,
+        queueCongestionPercent = 0f,
       )
     }
     monitor.collect(
@@ -98,7 +98,7 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 500L,
       totalBytesOut = 1500L,
       smoothedBitrate = 4000L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -116,21 +116,21 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 800L,
       totalBytesOut = 800L,
       smoothedBitrate = 6400L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
     monitor.collect(
       queueBytesOut = 200L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 1600L,
       smoothedBitrate = 6400L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
     monitor.collect(
       queueBytesOut = 100L,
       bytesOutPerSecond = 800L,
       totalBytesOut = 2400L,
       smoothedBitrate = 6400L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -140,9 +140,9 @@ class StreamingStatsMonitorTest {
 
   @Test
   fun `WHEN queue trend is mixed THEN throughput stays Unknown`() = runTest {
-    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, smoothedBitrate = 800L, queueCongested = false)
-    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, smoothedBitrate = 800L, queueCongested = false)
-    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, smoothedBitrate = 800L, queueCongested = false)
+    monitor.collect(queueBytesOut = 100L, bytesOutPerSecond = 100L, totalBytesOut = 100L, smoothedBitrate = 800L, queueCongestionPercent = 0f)
+    monitor.collect(queueBytesOut = 200L, bytesOutPerSecond = 100L, totalBytesOut = 200L, smoothedBitrate = 800L, queueCongestionPercent = 0f)
+    monitor.collect(queueBytesOut = 150L, bytesOutPerSecond = 100L, totalBytesOut = 300L, smoothedBitrate = 800L, queueCongestionPercent = 0f)
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
@@ -157,7 +157,7 @@ class StreamingStatsMonitorTest {
         bytesOutPerSecond = 100L,
         totalBytesOut = 100L,
         smoothedBitrate = 800L,
-        queueCongested = false,
+        queueCongestionPercent = 0f,
       )
     }
     monitor.reset()
@@ -166,7 +166,7 @@ class StreamingStatsMonitorTest {
       bytesOutPerSecond = 100L,
       totalBytesOut = 100L,
       smoothedBitrate = 800L,
-      queueCongested = false,
+      queueCongestionPercent = 0f,
     )
 
     val captor = argumentCaptor<StreamingStatsReport>()
@@ -184,12 +184,13 @@ class StreamingStatsMonitorTest {
         bytesOutPerSecond = 100L,
         totalBytesOut = 100L,
         smoothedBitrate = 800L,
-        queueCongested = true,
+        queueCongestionPercent = 100f,
       )
     }
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
     assertEquals(Throughput.INSUFFICIENT, captor.lastValue.throughput)
+    assertEquals(100f, captor.lastValue.queueCongestionPercent)
   }
 }

--- a/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
+++ b/common/src/test/java/com/pedro/common/StreamingStatsMonitorTest.kt
@@ -77,7 +77,7 @@ class StreamingStatsMonitorTest {
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(2)).onStreamingStats(captor.capture())
-    captor.allValues.forEach { assertEquals(Throughput.Unknown, it.throughput) }
+    captor.allValues.forEach { assertEquals(Throughput.UNKNOWN, it.throughput) }
   }
 
   @Test
@@ -99,7 +99,7 @@ class StreamingStatsMonitorTest {
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
-    assertEquals(Throughput.Insufficient, captor.lastValue.throughput)
+    assertEquals(Throughput.INSUFFICIENT, captor.lastValue.throughput)
     assertEquals(300L, captor.lastValue.queueBytesOut)
     assertEquals(500L, captor.lastValue.bytesOutPerSecond)
     assertEquals(4000L, captor.lastValue.bitrate)
@@ -128,7 +128,7 @@ class StreamingStatsMonitorTest {
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
-    assertEquals(Throughput.Sufficient, captor.lastValue.throughput)
+    assertEquals(Throughput.SUFFICIENT, captor.lastValue.throughput)
   }
 
   @Test
@@ -139,7 +139,7 @@ class StreamingStatsMonitorTest {
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(3)).onStreamingStats(captor.capture())
-    assertEquals(Throughput.Unknown, captor.lastValue.throughput)
+    assertEquals(Throughput.UNKNOWN, captor.lastValue.throughput)
   }
 
   @Test
@@ -162,6 +162,6 @@ class StreamingStatsMonitorTest {
 
     val captor = argumentCaptor<StreamingStatsReport>()
     verify(connectChecker, times(4)).onStreamingStats(captor.capture())
-    assertEquals(Throughput.Unknown, captor.lastValue.throughput)
+    assertEquals(Throughput.UNKNOWN, captor.lastValue.throughput)
   }
 }

--- a/library/src/main/java/com/pedro/library/util/streamclient/GenericStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/GenericStreamClient.kt
@@ -172,6 +172,8 @@ class GenericStreamClient(
 
   override fun getItemsInCache(): Int = connectedStreamClient?.getItemsInCache() ?: 0
 
+  override fun getQueueBytesOut(): Long = connectedStreamClient?.getQueueBytesOut() ?: 0L
+
   override fun getSentAudioFrames(): Long = connectedStreamClient?.getSentAudioFrames() ?: 0
 
   override fun getSentVideoFrames(): Long = connectedStreamClient?.getSentVideoFrames() ?: 0

--- a/library/src/main/java/com/pedro/library/util/streamclient/RtmpStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/RtmpStreamClient.kt
@@ -137,6 +137,8 @@ class RtmpStreamClient(
 
   override fun getItemsInCache(): Int = rtmpClient.getItemsInCache()
 
+  override fun getQueueBytesOut(): Long = rtmpClient.getQueueBytesOut()
+
   override fun getSentAudioFrames(): Long = rtmpClient.sentAudioFrames
 
   override fun getSentVideoFrames(): Long = rtmpClient.sentVideoFrames

--- a/library/src/main/java/com/pedro/library/util/streamclient/RtspStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/RtspStreamClient.kt
@@ -92,6 +92,8 @@ class RtspStreamClient(
 
   override fun getItemsInCache(): Int = rtspClient.getItemsInCache()
 
+  override fun getQueueBytesOut(): Long = rtspClient.getQueueBytesOut()
+
   override fun getSentAudioFrames(): Long = rtspClient.sentAudioFrames
 
   override fun getSentVideoFrames(): Long = rtspClient.sentVideoFrames

--- a/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
@@ -89,6 +89,8 @@ class SrtStreamClient(
 
   override fun getItemsInCache(): Int = srtClient.getItemsInCache()
 
+  override fun getQueueBytesOut(): Long = srtClient.getQueueBytesOut()
+
   override fun getSentAudioFrames(): Long = srtClient.sentAudioFrames
 
   override fun getSentVideoFrames(): Long = srtClient.sentVideoFrames

--- a/library/src/main/java/com/pedro/library/util/streamclient/StreamBaseClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/StreamBaseClient.kt
@@ -51,6 +51,7 @@ abstract class StreamBaseClient {
   abstract fun clearCache()
   abstract fun getCacheSize(): Int
   abstract fun getItemsInCache(): Int
+  abstract fun getQueueBytesOut(): Long
   abstract fun getSentAudioFrames(): Long
   abstract fun getSentVideoFrames(): Long
   abstract fun getBytesSend(): Long

--- a/library/src/main/java/com/pedro/library/util/streamclient/UdpStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/UdpStreamClient.kt
@@ -75,6 +75,8 @@ class UdpStreamClient(
 
   override fun getItemsInCache(): Int = udpClient.getItemsInCache()
 
+  override fun getQueueBytesOut(): Long = udpClient.getQueueBytesOut()
+
   override fun getSentAudioFrames(): Long = udpClient.sentAudioFrames
 
   override fun getSentVideoFrames(): Long = udpClient.sentVideoFrames

--- a/library/src/main/java/com/pedro/library/util/streamclient/WhipStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/WhipStreamClient.kt
@@ -79,6 +79,8 @@ class WhipStreamClient(
 
   override fun getItemsInCache(): Int = whipClient.getItemsInCache()
 
+  override fun getQueueBytesOut(): Long = whipClient.getQueueBytesOut()
+
   override fun getSentAudioFrames(): Long = whipClient.sentAudioFrames
 
   override fun getSentVideoFrames(): Long = whipClient.sentVideoFrames

--- a/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
+++ b/rtmp/src/main/java/com/pedro/rtmp/rtmp/RtmpClient.kt
@@ -649,6 +649,8 @@ class RtmpClient(private val connectChecker: ConnectChecker) {
 
   fun getItemsInCache(): Int = rtmpSender.getItemsInCache()
 
+  fun getQueueBytesOut(): Long = rtmpSender.getQueueBytesOut()
+
   /**
    * @param factor values from 0.1f to 1f
    * Set an exponential factor to the bitrate calculation to avoid bitrate spikes

--- a/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
+++ b/rtsp/src/main/java/com/pedro/rtsp/rtsp/RtspClient.kt
@@ -525,6 +525,8 @@ class RtspClient(private val connectChecker: ConnectChecker) {
 
   fun getItemsInCache(): Int = rtspSender.getItemsInCache()
 
+  fun getQueueBytesOut(): Long = rtspSender.getQueueBytesOut()
+
   /**
    * @param factor values from 0.1f to 1f
    * Set an exponential factor to the bitrate calculation to avoid bitrate spikes

--- a/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
+++ b/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
@@ -484,6 +484,8 @@ class SrtClient(private val connectChecker: ConnectChecker) {
 
   fun getItemsInCache(): Int = srtSender.getItemsInCache()
 
+  fun getQueueBytesOut(): Long = srtSender.getQueueBytesOut()
+
   /**
    * @param factor values from 0.1f to 1f
    * Set an exponential factor to the bitrate calculation to avoid bitrate spikes

--- a/udp/src/main/java/com/pedro/udp/UdpClient.kt
+++ b/udp/src/main/java/com/pedro/udp/UdpClient.kt
@@ -300,6 +300,8 @@ class UdpClient(private val connectChecker: ConnectChecker) {
 
   fun getItemsInCache(): Int = udpSender.getItemsInCache()
 
+  fun getQueueBytesOut(): Long = udpSender.getQueueBytesOut()
+
   /**
    * @param factor values from 0.1f to 1f
    * Set an exponential factor to the bitrate calculation to avoid bitrate spikes

--- a/whip/src/main/java/com/pedro/whip/WhipClient.kt
+++ b/whip/src/main/java/com/pedro/whip/WhipClient.kt
@@ -506,6 +506,8 @@ class WhipClient(private val connectChecker: ConnectChecker) {
 
     fun getItemsInCache(): Int = whipSender.getItemsInCache()
 
+    fun getQueueBytesOut(): Long = whipSender.getQueueBytesOut()
+
     /**
      * @param factor values from 0.1f to 1f
      * Set an exponential factor to the bitrate calculation to avoid bitrate spikes


### PR DESCRIPTION
## Summary

- Add `onStreamingStats(StreamingStatsReport)` to `BitrateChecker` for byte-accurate send-queue depth and 3-interval bandwidth trend classification.
- Add `StreamingStatsMonitor` in `common`, wired through `BaseSender` (all protocols: RTMP, RTSP, SRT, UDP, WHIP).
- Add `StreamBlockingQueue.getTotalSize()` to sum queued frame bytes.
- Mirrors [HaishinKit `NetworkMonitor`](https://github.com/HaishinKit/HaishinKit.swift/blob/main/HaishinKit/Sources/Network/NetworkMonitor.swift) behavior.
- Fully backward compatible: default empty callback; `onNewBitrate`, `hasCongestion`, and `BitrateAdapter` unchanged.

## Motivation

We ship a cross-platform streaming app: **HaishinKit on iOS**, **RootEncoder on Android**. Adaptive bitrate and congestion handling live in **shared Kotlin common code** — one strategy layer that expects the same stats shape on both platforms.

On iOS, HaishinKit exposes byte-accurate queue depth, send throughput, and sustained congestion trends via `NetworkMonitorReport` and throughput delegate events (`publishInsufficientBWOccured` / `publishSufficientBWOccured`). RootEncoder's existing `hasCongestion()` API only reports a single frame-count snapshot (% of send queue full). Strategies that need **byte queue depth** and **trend classification over multiple intervals** cannot derive that from frame counts alone, and cannot feed the shared common layer the same signals iOS already provides.

This PR adds an equivalent RootEncoder-native API so Android can supply matching telemetry to shared adaptive-bitrate logic — without polling or estimating queue size from frame count.

## API

New types in `com.pedro.common`:

| Type | Purpose |
|------|---------|
| `StreamingStatsReport` | Per-second report: `bytesOutPerSecond`, `queueBytesOut`, `totalBytesOut`, `throughput`, `bitrate`, `smoothedBitrate` |
| `Throughput` | `Unknown`, `Sufficient`, `Insufficient` — classified over 3 consecutive 1-second intervals |

New callback on `BitrateChecker`:

```java
default void onStreamingStats(StreamingStatsReport report) {}
```

Delivered on the main thread once per second while streaming, alongside existing `onNewBitrate`.

## HaishinKit mapping

| HaishinKit | RootEncoder |
|------------|-------------|
| `NetworkMonitorReport.currentBytesOutPerSecond` | `StreamingStatsReport.bytesOutPerSecond` |
| `NetworkMonitorReport.currentQueueBytesOut` | `StreamingStatsReport.queueBytesOut` |
| `NetworkMonitorEvent.publishInsufficientBWOccured` | `Throughput.Insufficient` |
| Stable queue over 3 samples | `Throughput.Sufficient` |
