### PR TITLE
Add Camera2 white balance lock and tap-to-meter APIs

### DIFF
--- a/Camera2ApiManager.kt
+++ b/Camera2ApiManager.kt
@@ -1,0 +1,1160 @@
+/*
+ * Copyright (C) 2024 pedroSG94.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pedro.encoder.input.video
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.Rect
+import android.graphics.SurfaceTexture
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraDevice
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CameraMetadata
+import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.CaptureResult
+import android.hardware.camera2.TotalCaptureResult
+import android.hardware.camera2.params.MeteringRectangle
+import android.hardware.camera2.params.OutputConfiguration
+import android.hardware.camera2.params.RggbChannelVector
+import android.hardware.camera2.params.SessionConfiguration
+import android.media.Image
+import android.media.ImageReader
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.util.Log
+import android.util.Range
+import android.util.Size
+import android.view.MotionEvent
+import android.view.Surface
+import android.view.View
+import androidx.annotation.RequiresApi
+import com.pedro.common.secureGet
+import com.pedro.encoder.input.video.Camera2ResolutionCalculator.getOptimalResolution
+import com.pedro.encoder.input.video.CameraHelper.Facing
+import com.pedro.encoder.input.video.facedetector.FaceDetectorCallback
+import com.pedro.encoder.input.video.facedetector.mapCamera2Faces
+import java.util.concurrent.Executors
+import java.util.concurrent.Semaphore
+import kotlin.math.abs
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.math.roundToInt
+
+/**
+ * Created by pedro on 4/03/17.
+ *
+ *
+ *
+ * Class for use surfaceEncoder to buffer encoder.
+ * Advantage = you can use all resolutions.
+ * Disadvantages = you cant control fps of the stream, because you cant know when the inputSurface
+ * was renderer.
+ *
+ *
+ * Note: you can use opengl for surfaceEncoder to buffer encoder on devices 21 < API > 16:
+ * https://github.com/google/grafika
+ */
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+class Camera2ApiManager(context: Context) {
+    private val TAG = "Camera2ApiManager"
+
+    private var cameraDevice: CameraDevice? = null
+    private var surfaceEncoder: Surface? = null
+    private val cameraManager = context.getSystemService(Context.CAMERA_SERVICE) as CameraManager
+    private var cameraCaptureSession: CameraCaptureSession? = null
+    var isPrepared: Boolean = false
+        private set
+    private var cameraId: String = "0"
+    private var physicalCameraId: String? = null
+    private var facing = Facing.BACK
+    private var builderInputSurface: CaptureRequest.Builder? = null
+    private var fingerSpacing = 0f
+    private var zoomLevel = 0f
+    var isLanternEnabled: Boolean = false
+        private set
+    var isVideoStabilizationEnabled: Boolean = false
+        private set
+    var isOpticalStabilizationEnabled: Boolean = false
+        private set
+    var isAutoFocusEnabled: Boolean = true
+        private set
+    var isAutoExposureEnabled: Boolean = false
+        private set
+    var isExposureLockEnabled: Boolean = false
+        private set
+    var isAutoWhiteBalanceEnabled: Boolean = true
+        private set
+    var isWhiteBalanceLockEnabled: Boolean = false
+        private set
+    var isRunning: Boolean = false
+        private set
+    private var fps = 30
+    private val semaphore = Semaphore(0)
+    private var cameraCallbacks: CameraCallbacks? = null
+    private var requiredSize: Size? = null
+    var dynamicFps = false
+
+    interface ImageCallback {
+        fun onImageAvailable(image: Image)
+    }
+
+    private var sensorOrientation = 0
+    private var faceSensorScale: Rect? = null
+    private var faceDetectorCallback: FaceDetectorCallback? = null
+    private var frameCapturedCallback: FrameCapturedCallback? = null
+    private var faceDetectionEnabled = false
+    private var faceDetectionMode = 0
+    private var imageReader: ImageReader? = null
+    private var availabilityCallback: CameraManager.AvailabilityCallback? = null
+
+    private var customCaptureCompletedCallback: ((session: CameraCaptureSession, request: CaptureRequest, result: TotalCaptureResult) -> Unit)? = null
+
+    init {
+        cameraId = try { getCameraIdForFacing(Facing.BACK) } catch (_: Exception) { "0" }
+    }
+
+    fun prepareCamera(surfaceTexture: SurfaceTexture, width: Int, height: Int, fps: Int) {
+        val optimalResolution = requiredSize ?: getOptimalResolution(Size(width, height), getCameraResolutions(facing))
+        Log.i(TAG, "optimal resolution set to: " + optimalResolution.width + "x" + optimalResolution.height)
+        if (!isRunning) this.surfaceEncoder?.release()
+        surfaceTexture.setDefaultBufferSize(optimalResolution.width, optimalResolution.height)
+        this.surfaceEncoder = Surface(surfaceTexture)
+        this.fps = fps
+        isPrepared = true
+    }
+
+    fun prepareCamera(surfaceTexture: SurfaceTexture, width: Int, height: Int, fps: Int, facing: Facing) {
+        this.facing = facing
+        prepareCamera(surfaceTexture, width, height, fps)
+    }
+
+    fun prepareCamera(surfaceTexture: SurfaceTexture, width: Int, height: Int, fps: Int, cameraId: String) {
+        this.cameraId = cameraId
+        this.facing = getFacingByCameraId(cameraManager, cameraId)
+        prepareCamera(surfaceTexture, width, height, fps)
+    }
+
+    fun prepareCamera(surface: Surface, fps: Int) {
+        this.surfaceEncoder = surface
+        this.fps = fps
+        isPrepared = true
+    }
+
+    private fun startPreview(cameraDevice: CameraDevice, handler: Handler) {
+        try {
+            val surface = surfaceEncoder ?: run {
+                cameraCallbacks?.onCameraError("You need prepare camera before open it")
+                return
+            }
+            val listSurfaces = mutableListOf<Surface>()
+            listSurfaces.add(surface)
+            imageReader?.let { listSurfaces.add(it.surface) }
+            val captureRequest = drawSurface(cameraDevice, listSurfaces)
+            createCaptureSession(
+                cameraDevice,
+                listSurfaces,
+                onConfigured = {
+                    cameraCaptureSession = it
+                    try {
+                        it.setRepeatingRequest(
+                            captureRequest,
+                            if (faceDetectionEnabled || frameCapturedCallback != null || customCaptureCompletedCallback != null) cb else null,
+                            handler
+                        )
+                    } catch (_: IllegalStateException) {
+                        reOpenCamera(cameraId)
+                    } catch (e: Exception) {
+                        cameraCallbacks?.onCameraError("Create capture session failed: " + e.message)
+                        Log.e(TAG, "Error", e)
+                    }
+                },
+                onConfiguredFailed = {
+                    it.close()
+                    cameraCallbacks?.onCameraError("Configuration failed")
+                    Log.e(TAG, "Configuration failed")
+                },
+                handler
+            )
+        } catch (_: IllegalStateException) {
+            reOpenCamera(cameraId)
+        } catch (e: Exception) {
+            cameraCallbacks?.onCameraError("Create capture session failed: " + e.message)
+            Log.e(TAG, "Error", e)
+        }
+    }
+
+
+
+    @Throws(IllegalStateException::class, Exception::class)
+    private fun drawSurface(cameraDevice: CameraDevice, surfaces: List<Surface>): CaptureRequest {
+        val builderInputSurface = cameraDevice.createCaptureRequest(CameraDevice.TEMPLATE_RECORD)
+        for (surface in surfaces) builderInputSurface.addTarget(surface)
+        builderInputSurface.set(CaptureRequest.CONTROL_MODE, CameraMetadata.CONTROL_MODE_AUTO)
+        if (dynamicFps) adaptFpsRangeDynamic(fps, builderInputSurface) else adaptFpsRange(fps, builderInputSurface)
+        this.builderInputSurface = builderInputSurface
+        return builderInputSurface.build()
+    }
+
+    private fun adaptFpsRange(expectedFps: Int, builderInputSurface: CaptureRequest.Builder) {
+        val fpsRanges = getSupportedFps(null, facing)
+        if (fpsRanges.isNotEmpty()) {
+            var closestRange = fpsRanges[0]
+            var measure = (abs((closestRange.lower - expectedFps).toDouble()) + abs(
+                (closestRange.upper - expectedFps).toDouble()
+            )).toInt()
+            for (range in fpsRanges) {
+                if (CameraHelper.discardCamera2Fps(range, facing)) continue
+                if (range.lower <= expectedFps && range.upper >= expectedFps) {
+                    val curMeasure = abs((((range.lower + range.upper) / 2) - expectedFps).toDouble()).toInt()
+                    if (curMeasure < measure) {
+                        closestRange = range
+                        measure = curMeasure
+                    } else if (curMeasure == measure) {
+                        if (abs((range.upper - expectedFps).toDouble()) < abs((closestRange.upper - expectedFps).toDouble())) {
+                            closestRange = range
+                            measure = curMeasure
+                        }
+                    }
+                }
+            }
+            Log.i(TAG, "fps: " + closestRange.lower + " - " + closestRange.upper)
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, closestRange)
+        }
+    }
+
+    private fun adaptFpsRangeDynamic(fps: Int, builderInputSurface: CaptureRequest.Builder) {
+        val validFps = min(60, fps)
+        // Find best FPS range instead of forcing strict [30, 30] which causes HAL duplication stutter
+        var bestRange = Range(validFps, validFps)
+        try {
+            val facing = if (cameraId == "1") Facing.FRONT else Facing.BACK
+            val supportedRanges = getSupportedFps(null, facing)
+
+            // Look for a range that maxes out at our target FPS, but allows dipping to save light (e.g. [24, 30] or [15, 30])
+            for (range in supportedRanges) {
+                if (range.upper == validFps && range.lower < validFps) {
+                    // Try to avoid dropping too low (e.g. [15, 30] can be too choppy, prefer [24, 30])
+                    if (range.lower >= 24) {
+                        bestRange = range
+                        break
+                    } else if (bestRange.lower == validFps || range.lower > bestRange.lower) {
+                        bestRange = range
+                    }
+                }
+            }
+            Log.i(TAG, "Selected dynamic FPS range: $bestRange for target $validFps")
+        } catch (e: Exception) {
+            Log.e(TAG, "Error finding dynamic FPS range", e)
+        }
+        builderInputSurface.set(CaptureRequest.CONTROL_AE_TARGET_FPS_RANGE, bestRange)
+    }
+
+    fun setCustomRequest(request: (CaptureRequest.Builder) -> Unit): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        request(builderInputSurface)
+        return applyRequest(builderInputSurface)
+    }
+
+    fun setCustomOnCaptureCompletedCallback(
+        callback: ((CameraCaptureSession, CaptureRequest, TotalCaptureResult) -> Unit)?
+    ) {
+        this.customCaptureCompletedCallback = callback
+    }
+
+    fun getSupportedFps(size: Size?, facing: Facing): List<Range<Int>> {
+        try {
+            val characteristics = cameraManager.getCameraCharacteristics(getCameraIdForFacing(facing))
+            val fpsSupported = characteristics.get(CameraCharacteristics.CONTROL_AE_AVAILABLE_TARGET_FPS_RANGES) ?: return emptyList()
+            return if (size != null) {
+                val streamConfigurationMap = characteristics.get(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP)
+                val list = mutableListOf<Range<Int>>()
+                val fd = streamConfigurationMap?.getOutputMinFrameDuration(SurfaceTexture::class.java, size) ?: return emptyList()
+                val maxFPS = (1e9 / fd).toInt()
+                for (r in fpsSupported) { if (r.upper <= maxFPS) { list.add(r) } }
+                list
+            } else listOf(*fpsSupported)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+            return emptyList()
+        }
+    }
+
+    val levelSupported: Int
+        get() {
+            val characteristics = cameraCharacteristics ?: return -1
+            return characteristics.secureGet(CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL) ?: -1
+        }
+
+    fun setRequiredResolution(size: Size?) {
+        requiredSize = size
+    }
+
+    fun openCameraBack() {
+        openCameraFacing(Facing.BACK)
+    }
+
+    fun openCameraFront() {
+        openCameraFacing(Facing.FRONT)
+    }
+
+    fun openLastCamera() {
+        openCameraId(cameraId)
+    }
+
+    fun setCameraId(cameraId: String) {
+        this.cameraId = cameraId
+    }
+
+    fun setAvailabilityCallback(callback: CameraManager.AvailabilityCallback?) {
+        if (callback == null) {
+            availabilityCallback?.let { cameraManager.unregisterAvailabilityCallback(it) }
+        } else {
+            cameraManager.registerAvailabilityCallback(callback, null)
+            availabilityCallback = callback
+        }
+    }
+
+    var cameraFacing: Facing
+        get() = facing
+        set(cameraFacing) {
+            try {
+                val cameraId = getCameraIdForFacing(cameraFacing)
+                facing = cameraFacing
+                this.cameraId = cameraId
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+            }
+        }
+
+    val cameraResolutionsBack: Array<Size>
+        get() = getCameraResolutions(Facing.BACK)
+
+    val cameraResolutionsFront: Array<Size>
+        get() = getCameraResolutions(Facing.FRONT)
+
+    fun getCameraResolutions(facing: Facing): Array<Size> = getCameraResolutions(getCameraIdForFacing(facing))
+
+    fun getCameraResolutions(cameraId: String): Array<Size> {
+        try {
+            val characteristics = cameraManager.getCameraCharacteristics(cameraId)
+            val streamConfigurationMap = characteristics.secureGet(CameraCharacteristics.SCALER_STREAM_CONFIGURATION_MAP) ?: return arrayOf()
+            val outputSizes = streamConfigurationMap.getOutputSizes(SurfaceTexture::class.java)
+            return outputSizes ?: arrayOf()
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+            return arrayOf()
+        }
+    }
+
+    val cameraCharacteristics: CameraCharacteristics?
+        get() {
+            try {
+                return cameraManager.getCameraCharacteristics(cameraId)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+                return null
+            }
+        }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun getPhysicalCamerasAvailable(): List<String> {
+        return cameraCharacteristics?.physicalCameraIds?.toList() ?: emptyList()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun setPhysicalCamera(id: String?) {
+        physicalCameraId = id
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    fun openPhysicalCamera(id: String?) {
+        setPhysicalCamera(id)
+        if (isRunning) reOpenCamera(cameraId)
+        else openCameraId(cameraId)
+    }
+
+    private fun applyRequest(builder: CaptureRequest.Builder): Boolean {
+        this.builderInputSurface = builder
+        val cameraCaptureSession = this.cameraCaptureSession ?: return false
+        try {
+            cameraCaptureSession.setRepeatingRequest(
+                builder.build(),
+                if (faceDetectionEnabled || frameCapturedCallback != null || customCaptureCompletedCallback != null) cb else null, null
+            )
+            return true
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+            return false
+        }
+    }
+
+    /**
+     * @param mode value from CameraCharacteristics.CONTROL_AWB_MODE_*
+     */
+    fun enableAutoWhiteBalance(mode: Int): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES) ?: return false
+        if (!modes.contains(mode)) return false
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, mode)
+        isAutoWhiteBalanceEnabled = applyRequest(builderInputSurface)
+        return isAutoWhiteBalanceEnabled
+    }
+
+    fun disableAutoWhiteBalance() {
+        val characteristics = cameraCharacteristics ?: return
+        val builderInputSurface = this.builderInputSurface ?: return
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES) ?: return
+        if (!modes.contains(CaptureRequest.CONTROL_AWB_MODE_OFF)) return
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_OFF)
+        applyRequest(builderInputSurface)
+        isAutoWhiteBalanceEnabled = false
+    }
+
+    fun getAutoWhiteBalanceModesAvailable(): List<Int> {
+        val characteristics = cameraCharacteristics ?: return listOf()
+        return characteristics.secureGet(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES)?.toList() ?: listOf()
+    }
+
+    fun getWhiteBalance(): Int {
+        val default = CameraCharacteristics.CONTROL_AWB_MODE_AUTO
+        val builderInputSurface = this.builderInputSurface ?: return default
+        return builderInputSurface.secureGet(CaptureRequest.CONTROL_AWB_MODE) ?: default
+    }
+
+    fun setColorCorrectionGains(red: Float, greenEven: Float, greenOdd: Float, blue: Float): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val modes = characteristics.secureGet(CameraCharacteristics.COLOR_CORRECTION_AVAILABLE_ABERRATION_MODES) ?: return false
+        if (!modes.contains(CaptureRequest.COLOR_CORRECTION_MODE_TRANSFORM_MATRIX)) return false
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, CaptureRequest.CONTROL_AWB_MODE_OFF)
+        builderInputSurface.set(CaptureRequest.COLOR_CORRECTION_MODE, CaptureRequest.COLOR_CORRECTION_MODE_TRANSFORM_MATRIX)
+        builderInputSurface.set(CaptureRequest.COLOR_CORRECTION_TRANSFORM, characteristics.get(CameraCharacteristics.SENSOR_CALIBRATION_TRANSFORM1))
+        val vector = RggbChannelVector(red, greenEven, greenOdd, blue)
+        builderInputSurface.set(CaptureRequest.COLOR_CORRECTION_GAINS, vector)
+        return applyRequest(builderInputSurface)
+    }
+
+    fun enableAutoExposure(): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES) ?: return false
+        if (!modes.contains(CaptureRequest.CONTROL_AE_MODE_ON)) return false
+        builderInputSurface.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
+        isAutoExposureEnabled = applyRequest(builderInputSurface)
+        return isAutoExposureEnabled
+    }
+
+    fun disableAutoExposure() {
+        val characteristics = cameraCharacteristics ?: return
+        val builderInputSurface = this.builderInputSurface ?: return
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES) ?: return
+        if (!modes.contains(CaptureRequest.CONTROL_AE_MODE_ON)) return
+        builderInputSurface.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF)
+        applyRequest(builderInputSurface)
+        isAutoExposureEnabled = false
+    }
+
+    /**
+     * Lock auto exposure to the current value. The camera will stop adjusting exposure
+     * automatically (useful to avoid exposure changes produced by faces or lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    fun enableExposureLock(): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            val available = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_LOCK_AVAILABLE) ?: return false
+            if (!available) return false
+        }
+        builderInputSurface.set(CaptureRequest.CONTROL_AE_LOCK, true)
+        isExposureLockEnabled = applyRequest(builderInputSurface)
+        return isExposureLockEnabled
+    }
+
+    fun disableExposureLock() {
+        val builderInputSurface = this.builderInputSurface ?: return
+        builderInputSurface.set(CaptureRequest.CONTROL_AE_LOCK, false)
+        applyRequest(builderInputSurface)
+        isExposureLockEnabled = false
+    }
+
+    /**
+     * Lock auto white balance to the current value. The camera will stop adjusting white balance
+     * automatically (useful to avoid color shifts from lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    fun enableWhiteBalanceLock(): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_LOCK, true)
+        isWhiteBalanceLockEnabled = applyRequest(builderInputSurface)
+        return isWhiteBalanceLockEnabled
+    }
+
+    fun disableWhiteBalanceLock() {
+        val builderInputSurface = this.builderInputSurface ?: return
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_LOCK, false)
+        applyRequest(builderInputSurface)
+        isWhiteBalanceLockEnabled = false
+    }
+
+    fun enableVideoStabilization(): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES) ?: return false
+        if (!modes.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) return false
+        builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE, CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)
+        isVideoStabilizationEnabled = applyRequest(builderInputSurface)
+        return isVideoStabilizationEnabled
+    }
+
+    fun disableVideoStabilization() {
+        val characteristics = cameraCharacteristics ?: return
+        val builderInputSurface = this.builderInputSurface ?: return
+        val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AVAILABLE_VIDEO_STABILIZATION_MODES) ?: return
+        if (!modes.contains(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_ON)) return
+        builderInputSurface.set(CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE, CaptureRequest.CONTROL_VIDEO_STABILIZATION_MODE_OFF)
+        applyRequest(builderInputSurface)
+        isVideoStabilizationEnabled = false
+    }
+
+    fun enableOpticalVideoStabilization(): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val opticalStabilizationModes = characteristics.secureGet(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION) ?: return false
+        if (!opticalStabilizationModes.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) return false
+        builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE, CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)
+        isOpticalStabilizationEnabled = applyRequest(builderInputSurface)
+        return isOpticalStabilizationEnabled
+    }
+
+    fun disableOpticalVideoStabilization() {
+        val characteristics = cameraCharacteristics ?: return
+        val builderInputSurface = this.builderInputSurface ?: return
+        val modes = characteristics.secureGet(CameraCharacteristics.LENS_INFO_AVAILABLE_OPTICAL_STABILIZATION) ?: return
+        if (!modes.contains(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_ON)) return
+        builderInputSurface.set(CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE, CaptureRequest.LENS_OPTICAL_STABILIZATION_MODE_OFF)
+        applyRequest(builderInputSurface)
+        isOpticalStabilizationEnabled = false
+    }
+
+    fun setFocusDistance(distance: Float) {
+        val builderInputSurface = this.builderInputSurface ?: return
+        builderInputSurface.set(CaptureRequest.LENS_FOCUS_DISTANCE, max(0f, distance))
+        applyRequest(builderInputSurface)
+    }
+
+    fun getCurrentCameraId()  = cameraId
+
+    var exposure: Int
+        get() {
+            val builderInputSurface = this.builderInputSurface ?: return 0
+            return builderInputSurface.secureGet(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION) ?: 0
+        }
+        set(value) {
+            val characteristics = cameraCharacteristics ?: return
+            val builderInputSurface = this.builderInputSurface ?: return
+            val supportedExposure = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE) ?: return
+            val v = value.coerceIn(supportedExposure.lower, supportedExposure.upper)
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_EXPOSURE_COMPENSATION, v)
+            applyRequest(builderInputSurface)
+        }
+
+
+    val maxExposure: Int
+        get() {
+            val characteristics = cameraCharacteristics ?: return 0
+            val supportedExposure = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE)?.upper ?: 0
+            return supportedExposure
+        }
+
+    val minExposure: Int
+        get() {
+            val characteristics = cameraCharacteristics ?: return 0
+            val supportedExposure = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_COMPENSATION_RANGE)?.lower ?: 0
+            return supportedExposure
+        }
+
+    fun tapToFocus(view: View, event: MotionEvent): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val characteristics = cameraCharacteristics ?: return false
+        val session = cameraCaptureSession ?: return false
+        if (characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AF) == 0) return false
+        val focusTag = "focus"
+        val sensorArraySize = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return false
+        val x = event.x
+        val y = event.y
+        val focusX = (x / view.width.toFloat()) * sensorArraySize.width()
+        val focusY = (y / view.height.toFloat()) * sensorArraySize.height()
+        val focusRect = MeteringRectangle(
+            (focusX - 100).toInt().coerceIn(0, sensorArraySize.width()),
+            (focusY - 100).toInt().coerceIn(0, sensorArraySize.height()),
+            (100 * 2).coerceIn(0, sensorArraySize.width()),
+            (100 * 2).coerceIn(0, sensorArraySize.height()),
+            MeteringRectangle.METERING_WEIGHT_MAX
+        )
+
+        val captureCallbackHandler: CameraCaptureSession.CaptureCallback =
+            object : CameraCaptureSession.CaptureCallback() {
+                override fun onCaptureCompleted(session: CameraCaptureSession, request: CaptureRequest, result: TotalCaptureResult) {
+                    super.onCaptureCompleted(session, request, result)
+                    if (request.tag == focusTag) {
+                        session.stopRepeating()
+                        val area = request.get(CaptureRequest.CONTROL_AF_REGIONS)
+                        builderInputSurface.setTag("")
+                        builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_AUTO)
+                        builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_IDLE)
+                        builderInputSurface.set(CaptureRequest.CONTROL_AF_REGIONS, area)
+                        applyRequest(builderInputSurface)
+                    }
+                }
+            }
+        try {
+            session.stopRepeating()
+            builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL)
+            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_OFF)
+            session.capture(builderInputSurface.build(), captureCallbackHandler, null)
+
+            builderInputSurface.set(CaptureRequest.CONTROL_AF_REGIONS, arrayOf(focusRect))
+            builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CameraMetadata.CONTROL_AF_MODE_AUTO)
+            builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_START)
+            builderInputSurface.setTag(focusTag)
+            session.capture(builderInputSurface.build(), captureCallbackHandler, null)
+            isAutoFocusEnabled = true
+            return true
+        } catch (_: Exception) {
+            return false
+        }
+    }
+
+    /**
+     * Tap to meter exposure at a specific point.
+     *
+     * @param view The view where the touch event occurred
+     * @param event The touch event containing coordinates
+     * @return true if successful, false otherwise
+     */
+    fun tapToMeterExposure(view: View, event: MotionEvent): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val characteristics = cameraCharacteristics ?: return false
+        if (characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE) == 0) return false
+
+        val sensorArraySize = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return false
+        val regionX = (event.x / view.width.toFloat()) * sensorArraySize.width()
+        val regionY = (event.y / view.height.toFloat()) * sensorArraySize.height()
+
+        val aeRect = MeteringRectangle(
+            (regionX - 100).toInt().coerceIn(0, sensorArraySize.width()),
+            (regionY - 100).toInt().coerceIn(0, sensorArraySize.height()),
+            (100 * 2).coerceIn(0, sensorArraySize.width()),
+            (100 * 2).coerceIn(0, sensorArraySize.height()),
+            MeteringRectangle.METERING_WEIGHT_MAX
+        )
+
+        return try {
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_REGIONS, arrayOf(aeRect))
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_MODE, CameraMetadata.CONTROL_AE_MODE_ON)
+            isAutoExposureEnabled = applyRequest(builderInputSurface)
+            isAutoExposureEnabled
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting AE region", e)
+            false
+        }
+    }
+
+    /**
+     * Tap to meter white balance at a specific point.
+     *
+     * @param view The view where the touch event occurred
+     * @param event The touch event containing coordinates
+     * @return true if successful, false otherwise
+     */
+    fun tapToMeterWhiteBalance(view: View, event: MotionEvent): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val characteristics = cameraCharacteristics ?: return false
+        if (characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AWB) == 0) return false
+
+        val sensorArraySize = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return false
+        val regionX = (event.x / view.width.toFloat()) * sensorArraySize.width()
+        val regionY = (event.y / view.height.toFloat()) * sensorArraySize.height()
+
+        val awbRect = MeteringRectangle(
+            (regionX - 100).toInt().coerceIn(0, sensorArraySize.width()),
+            (regionY - 100).toInt().coerceIn(0, sensorArraySize.height()),
+            (100 * 2).coerceIn(0, sensorArraySize.width()),
+            (100 * 2).coerceIn(0, sensorArraySize.height()),
+            MeteringRectangle.METERING_WEIGHT_MAX
+        )
+
+        return try {
+            builderInputSurface.set(CaptureRequest.CONTROL_AWB_REGIONS, arrayOf(awbRect))
+            builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, CameraMetadata.CONTROL_AWB_MODE_AUTO)
+            isAutoWhiteBalanceEnabled = applyRequest(builderInputSurface)
+            isAutoWhiteBalanceEnabled
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting AWB region", e)
+            false
+        }
+    }
+
+    /**
+     * Select camera facing
+     *
+     * @param selectedCameraFacing - CameraCharacteristics.LENS_FACING_FRONT,
+     * CameraCharacteristics.LENS_FACING_BACK,
+     * CameraCharacteristics.LENS_FACING_EXTERNAL
+     */
+    fun openCameraFacing(selectedCameraFacing: Facing) {
+        try {
+            val cameraId = getCameraIdForFacing(selectedCameraFacing)
+            openCameraId(cameraId)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+        }
+    }
+
+    val isLanternSupported: Boolean
+        get() {
+            val characteristics = cameraCharacteristics ?: return false
+            val available = characteristics.secureGet(CameraCharacteristics.FLASH_INFO_AVAILABLE) ?: return false
+            return available
+        }
+
+    /**
+     * @required: <uses-permission android:name="android.permission.FLASHLIGHT"></uses-permission>
+     */
+    @Throws(Exception::class)
+    fun enableLantern() {
+        val builderInputSurface = this.builderInputSurface ?: return
+        if (isLanternSupported) {
+            try {
+                builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_TORCH)
+                isLanternEnabled = applyRequest(builderInputSurface)
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+            }
+        } else {
+            Log.e(TAG, "Lantern unsupported")
+            throw Exception("Lantern unsupported")
+        }
+    }
+
+    /**
+     * @required: <uses-permission android:name="android.permission.FLASHLIGHT"></uses-permission>
+     */
+    fun disableLantern() {
+        val characteristics = cameraCharacteristics ?: return
+        val builderInputSurface = this.builderInputSurface ?: return
+        val available = characteristics.secureGet(CameraCharacteristics.FLASH_INFO_AVAILABLE) ?: return
+        if (available) {
+            try {
+                builderInputSurface.set(CaptureRequest.FLASH_MODE, CameraMetadata.FLASH_MODE_OFF)
+                applyRequest(builderInputSurface)
+                isLanternEnabled = false
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+            }
+        }
+    }
+
+    fun enableAutoFocus(): Boolean {
+        var result = false
+        val characteristics = cameraCharacteristics ?: return false
+        val supportedFocusModes = characteristics.secureGet(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        try {
+            if (supportedFocusModes.isNotEmpty()) {
+                //cancel any existing AF trigger
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_TRIGGER, CameraMetadata.CONTROL_AF_TRIGGER_CANCEL)
+                builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF)
+                applyRequest(builderInputSurface)
+                // Prefer CONTINUOUS_VIDEO: same smooth AF as CONTINUOUS_PICTURE but defers
+                // fine adjustments to not interrupt frame delivery (no dropped frames on focus hunt).
+                if (supportedFocusModes.contains(CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO)) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_VIDEO)
+                    isAutoFocusEnabled = true
+                } else if (supportedFocusModes.contains(CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_CONTINUOUS_PICTURE)
+                    isAutoFocusEnabled = true
+                } else if (supportedFocusModes.contains(CaptureRequest.CONTROL_AF_MODE_AUTO)) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_AUTO)
+                    isAutoFocusEnabled = true
+                } else {
+                    builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, supportedFocusModes[0])
+                    isAutoFocusEnabled = false
+                }
+                applyRequest(builderInputSurface)
+            }
+            result = isAutoFocusEnabled
+        } catch (e: Exception) {
+            isAutoFocusEnabled = false
+            Log.e(TAG, "Error", e)
+        }
+        return result
+    }
+
+    fun disableAutoFocus(): Boolean {
+        val result = false
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val supportedFocusModes = characteristics.secureGet(CameraCharacteristics.CONTROL_AF_AVAILABLE_MODES) ?: return false
+        for (mode in supportedFocusModes) {
+            try {
+                if (mode == CaptureRequest.CONTROL_AF_MODE_OFF) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_AF_MODE, CaptureRequest.CONTROL_AF_MODE_OFF)
+                    applyRequest(builderInputSurface)
+                    isAutoFocusEnabled = false
+                    return true
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+            }
+        }
+        return result
+    }
+
+    fun enableFaceDetection(faceDetectorCallback: FaceDetectorCallback?): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
+        val builderInputSurface = this.builderInputSurface ?: return false
+        faceSensorScale = characteristics.secureGet(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE)
+        sensorOrientation = characteristics.secureGet(CameraCharacteristics.SENSOR_ORIENTATION) ?: return false
+        val fd = characteristics.secureGet(CameraCharacteristics.STATISTICS_INFO_AVAILABLE_FACE_DETECT_MODES) ?: return false
+        val maxFD = characteristics.secureGet(CameraCharacteristics.STATISTICS_INFO_MAX_FACE_COUNT) ?: return false
+        if (fd.isEmpty() || maxFD <= 0) return false
+        this.faceDetectorCallback = faceDetectorCallback
+        faceDetectionEnabled = true
+        faceDetectionMode = fd.toList().max()
+        builderInputSurface.set(CaptureRequest.STATISTICS_FACE_DETECT_MODE, faceDetectionMode)
+        applyRequest(builderInputSurface)
+        return true
+    }
+
+
+    fun enableFrameCaptureCallback(frameCapturedCallback: FrameCapturedCallback?) {
+        this.frameCapturedCallback = frameCapturedCallback
+    }
+
+    fun disableFaceDetection() {
+        if (faceDetectionEnabled) {
+            faceDetectorCallback = null
+            faceDetectionEnabled = false
+            faceDetectionMode = 0
+            builderInputSurface?.let {
+                it.set(CaptureRequest.STATISTICS_FACE_DETECT_MODE, CaptureRequest.STATISTICS_FACE_DETECT_MODE_OFF)
+                applyRequest(it)
+            }
+        }
+    }
+
+    fun isFaceDetectionEnabled() = faceDetectionEnabled
+
+    fun setCameraCallbacks(cameraCallbacks: CameraCallbacks?) {
+        this.cameraCallbacks = cameraCallbacks
+    }
+
+    private val cb: CameraCaptureSession.CaptureCallback = object : CameraCaptureSession.CaptureCallback() {
+        override fun onCaptureCompleted(
+            session: CameraCaptureSession,
+            request: CaptureRequest,
+            result: TotalCaptureResult
+        ) {
+            customCaptureCompletedCallback?.invoke(session, request, result)
+
+            val faces = result.get(CaptureResult.STATISTICS_FACES) ?: return
+            faceDetectorCallback?.onGetFaces(
+                faces = mapCamera2Faces(faces = faces),
+                scaleSensor = faceSensorScale,
+                sensorOrientation = sensorOrientation
+            )
+        }
+
+        override fun onCaptureStarted(
+            session: CameraCaptureSession,
+            request: CaptureRequest,
+            timestamp: Long,
+            frameNumber: Long
+        ) {
+            frameCapturedCallback?.onFrameCaptured(
+                frameNumber = frameNumber,
+                timestamp = timestamp
+            )
+        }
+    }
+
+    @SuppressLint("MissingPermission")
+    fun openCameraId(cameraId: String) {
+        this.cameraId = cameraId
+        if (isPrepared) {
+            val cameraHandlerThread = HandlerThread("$TAG Id = $cameraId")
+            cameraHandlerThread.start()
+            val handler = Handler(cameraHandlerThread.looper)
+            try {
+                cameraManager.openCamera(cameraId, object: CameraDevice.StateCallback() {
+                    override fun onOpened(cameraDevice: CameraDevice) {
+                        this@Camera2ApiManager.cameraDevice = cameraDevice
+                        startPreview(cameraDevice, handler)
+                        semaphore.release()
+                        cameraCallbacks?.onCameraOpened()
+                        Log.i(TAG, "Camera opened")
+                    }
+
+                    override fun onClosed(camera: CameraDevice) {
+                        super.onClosed(camera)
+                        handler.looper.quitSafely()
+                    }
+
+                    override fun onDisconnected(cameraDevice: CameraDevice) {
+                        cameraDevice.close()
+                        semaphore.release()
+                        cameraCallbacks?.onCameraDisconnected()
+                        Log.i(TAG, "Camera disconnected")
+                    }
+
+                    override fun onError(cameraDevice: CameraDevice, i: Int) {
+                        cameraDevice.close()
+                        semaphore.release()
+                        cameraCallbacks?.onCameraError("Open camera failed: $i")
+                        Log.e(TAG, "Open failed: $i")
+                    }
+
+                }, handler)
+                semaphore.acquireUninterruptibly()
+                val cameraCharacteristics = cameraManager.getCameraCharacteristics(cameraId)
+                isRunning = true
+                val facing = cameraCharacteristics.secureGet(CameraCharacteristics.LENS_FACING) ?: return
+                this.facing = if (CameraMetadata.LENS_FACING_FRONT == facing) Facing.FRONT else Facing.BACK
+                cameraCallbacks?.onCameraChanged(this.facing)
+            } catch (e: Exception) {
+                cameraCallbacks?.onCameraError("Open camera $cameraId failed")
+                Log.e(TAG, "Error", e)
+            }
+        } else {
+            throw IllegalStateException("You need prepare camera before open it")
+        }
+    }
+
+    val camerasAvailable: Array<String> = cameraManager.cameraIdList
+
+    fun switchCamera() {
+        try {
+            val cameraId = if (cameraDevice == null || facing == Facing.FRONT) {
+                getCameraIdForFacing(Facing.BACK)
+            } else {
+                getCameraIdForFacing(Facing.FRONT)
+            }
+            reOpenCamera(cameraId)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+        }
+    }
+
+    fun reOpenCamera(cameraId: String) {
+        val surface = surfaceEncoder
+        if (cameraDevice != null && surface != null) {
+            closeCamera(false)
+            prepareCamera(surface, fps)
+            openCameraId(cameraId)
+        }
+    }
+
+    val zoomRange: Range<Float>
+        get() {
+            val characteristics = cameraCharacteristics ?: return Range(1f, 1f)
+            var zoomRanges: Range<Float>? = null
+            //only camera limited or better support this feature.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && levelSupported != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+                zoomRanges = characteristics.secureGet(CameraCharacteristics.CONTROL_ZOOM_RATIO_RANGE)
+            }
+            if (zoomRanges == null) {
+                val maxZoom = characteristics.secureGet(CameraCharacteristics.SCALER_AVAILABLE_MAX_DIGITAL_ZOOM) ?: 1f
+                zoomRanges = Range(1f, maxZoom)
+            }
+            return zoomRanges
+        }
+
+    var zoom: Float
+        get() = zoomLevel
+        set(level) {
+            val characteristics = cameraCharacteristics ?: return
+            val builderInputSurface = this.builderInputSurface ?: return
+            val l = level.coerceIn(zoomRange.lower, zoomRange.upper)
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && levelSupported != CameraMetadata.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+                    builderInputSurface.set(CaptureRequest.CONTROL_ZOOM_RATIO, l)
+                } else {
+                    val rect = characteristics.secureGet(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return
+                    //This ratio is the ratio of cropped Rect to Camera's original(Maximum) Rect
+                    val ratio = 1f / l
+                    //croppedWidth and croppedHeight are the pixels cropped away, not pixels after cropped
+                    val croppedWidth = rect.width() - (rect.width().toFloat() * ratio).roundToInt()
+                    val croppedHeight = rect.height() - (rect.height().toFloat() * ratio).roundToInt()
+                    //Finally, zoom represents the zoomed visible area
+                    val zoom = Rect(
+                        croppedWidth / 2, croppedHeight / 2, rect.width() - croppedWidth / 2,
+                        rect.height() - croppedHeight / 2
+                    )
+                    builderInputSurface.set(CaptureRequest.SCALER_CROP_REGION, zoom)
+                }
+                applyRequest(builderInputSurface)
+                zoomLevel = l
+            } catch (e: Exception) {
+                Log.e(TAG, "Error", e)
+            }
+        }
+
+    fun getOpticalZooms(): Array<Float> {
+        val characteristics = cameraCharacteristics ?: return arrayOf()
+        return characteristics.secureGet(CameraCharacteristics.LENS_INFO_AVAILABLE_FOCAL_LENGTHS)?.toTypedArray() ?: arrayOf()
+    }
+
+    fun setOpticalZoom(level: Float) {
+        val builderInputSurface = this.builderInputSurface ?: return
+        try {
+            builderInputSurface.set(CaptureRequest.LENS_FOCAL_LENGTH, level)
+            applyRequest(builderInputSurface)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error", e)
+        }
+    }
+
+    @JvmOverloads
+    fun setZoom(event: MotionEvent, delta: Float = 0.1f) {
+        if (event.pointerCount < 2 || event.action != MotionEvent.ACTION_MOVE) return
+        val currentFingerSpacing = CameraHelper.getFingerSpacing(event)
+        if (currentFingerSpacing > fingerSpacing) {
+            zoom += delta
+        } else if (currentFingerSpacing < fingerSpacing) {
+            zoom -= delta
+        }
+        fingerSpacing = currentFingerSpacing
+    }
+
+    @JvmOverloads
+    fun closeCamera(resetSurface: Boolean = true) {
+        isLanternEnabled = false
+        zoomLevel = 1.0f
+        cameraCaptureSession?.close()
+        cameraCaptureSession = null
+        cameraDevice?.close()
+        cameraDevice = null
+        if (resetSurface) {
+            surfaceEncoder?.release()
+            surfaceEncoder = null
+            builderInputSurface = null
+        }
+        isPrepared = false
+        isRunning = false
+    }
+
+    fun addImageListener(width: Int, height: Int, format: Int, maxImages: Int, autoClose: Boolean, listener: ImageCallback) {
+        val wasRunning = isRunning
+        closeCamera(false)
+        this.imageReader?.close()
+        val imageThread = HandlerThread("$TAG imageThread")
+        imageThread.start()
+        val imageReader = ImageReader.newInstance(width, height, format, maxImages)
+        imageReader.setOnImageAvailableListener({ reader: ImageReader ->
+            val image = reader.acquireLatestImage()
+            if (image != null) {
+                listener.onImageAvailable(image)
+                if (autoClose) image.close()
+            }
+        }, Handler(imageThread.looper))
+        this.imageReader = imageReader
+        val surface = surfaceEncoder
+        if (wasRunning && surface != null) {
+            prepareCamera(surface, fps)
+            openLastCamera()
+        }
+    }
+
+    fun removeImageListener() {
+        val imageReader = this.imageReader ?: return
+        val wasRunning = isRunning
+        if (wasRunning) closeCamera(false)
+        imageReader.close()
+        this.imageReader = null
+        val surface = surfaceEncoder
+        if (wasRunning && surface != null) {
+            prepareCamera(surface, fps)
+            openLastCamera()
+        }
+    }
+
+    @JvmOverloads
+    fun getCameraIdForFacing(facing: Facing, cameraManager: CameraManager = this.cameraManager): String {
+        val selectedFacing = if (facing == Facing.BACK) CameraMetadata.LENS_FACING_BACK else CameraMetadata.LENS_FACING_FRONT
+        val ids = cameraManager.cameraIdList
+        for (cameraId in ids) {
+            val cameraFacing = cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING)
+            if (cameraFacing != null && cameraFacing == selectedFacing) {
+                return cameraId
+            }
+        }
+        if (ids.isEmpty()) throw CameraOpenException("Camera no detected")
+        return ids[0]
+    }
+
+    private fun getFacingByCameraId(cameraManager: CameraManager, cameraId: String): Facing {
+        try {
+            for (id in cameraManager.cameraIdList) {
+                if (id == cameraId) {
+                    val cameraFacing = cameraManager.getCameraCharacteristics(cameraId).get(CameraCharacteristics.LENS_FACING)
+                    return if (cameraFacing == CameraMetadata.LENS_FACING_BACK) Facing.BACK
+                    else Facing.FRONT
+                }
+            }
+            return Facing.BACK
+        } catch (_: Exception) {
+            return Facing.BACK
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    private fun createCaptureSession(
+        cameraDevice: CameraDevice,
+        surfaces: List<Surface>,
+        onConfigured: (CameraCaptureSession) -> Unit,
+        onConfiguredFailed: (CameraCaptureSession) -> Unit,
+        handler: Handler?
+    ) {
+        val callback = object: CameraCaptureSession.StateCallback() {
+            override fun onConfigured(cameraCaptureSession: CameraCaptureSession) {
+                onConfigured(cameraCaptureSession)
+            }
+
+            override fun onConfigureFailed(cameraCaptureSession: CameraCaptureSession) {
+                onConfiguredFailed(cameraCaptureSession)
+            }
+        }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            val configurations = surfaces.map { OutputConfiguration(it) }
+            configurations.forEach { it.setPhysicalCameraId(physicalCameraId) }
+            val config = SessionConfiguration(
+                SessionConfiguration.SESSION_REGULAR,
+                configurations,
+                Executors.newSingleThreadExecutor(),
+                callback
+            )
+            cameraDevice.createCaptureSession(config)
+        } else {
+            cameraDevice.createCaptureSession(surfaces, callback, handler)
+        }
+    }
+}

--- a/Camera2Base.java
+++ b/Camera2Base.java
@@ -1,0 +1,1174 @@
+/*
+ * Copyright (C) 2024 pedroSG94.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pedro.library.base;
+
+import android.content.Context;
+import android.graphics.Point;
+import android.hardware.camera2.CameraCharacteristics;
+import android.media.MediaCodec;
+import android.media.MediaFormat;
+import android.media.MediaRecorder;
+import android.os.Build;
+import android.util.Log;
+import android.util.Range;
+import android.util.Size;
+import android.view.MotionEvent;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import com.pedro.common.AudioCodec;
+import com.pedro.common.TimeUtils;
+import com.pedro.common.VideoCodec;
+import com.pedro.encoder.CodecErrorCallback;
+import com.pedro.encoder.TimestampMode;
+import com.pedro.encoder.audio.AudioEncoder;
+import com.pedro.encoder.audio.GetAudioData;
+import com.pedro.encoder.input.audio.CustomAudioEffect;
+import com.pedro.encoder.input.audio.GetMicrophoneData;
+import com.pedro.encoder.input.audio.MicrophoneManager;
+import com.pedro.encoder.input.video.Camera2ApiManager;
+import com.pedro.encoder.input.video.CameraCallbacks;
+import com.pedro.encoder.input.video.CameraHelper;
+import com.pedro.encoder.input.video.CameraOpenException;
+import com.pedro.encoder.input.video.FrameCapturedCallback;
+import com.pedro.encoder.input.video.facedetector.FaceDetectorCallback;
+import com.pedro.encoder.utils.CodecUtil;
+import com.pedro.encoder.video.FormatVideoEncoder;
+import com.pedro.encoder.video.GetVideoData;
+import com.pedro.encoder.video.VideoEncoder;
+import com.pedro.library.base.recording.RecordController;
+import com.pedro.library.util.AndroidMuxerRecordController;
+import com.pedro.library.util.FpsListener;
+import com.pedro.library.util.streamclient.StreamBaseClient;
+import com.pedro.library.view.GlInterface;
+import com.pedro.library.view.GlStreamInterface;
+import com.pedro.library.view.OpenGlView;
+
+import java.io.FileDescriptor;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Wrapper to stream with camera2 api and microphone. Support stream with SurfaceView, TextureView,
+ * OpenGlView(Custom SurfaceView that use OpenGl) and Context(background mode). All views use
+ * Surface to buffer encoding mode for H264.
+ *
+ * API requirements:
+ * API 21+.
+ *
+ * Created by pedro on 7/07/17.
+ */
+@RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+public abstract class Camera2Base {
+
+    private static final String TAG = "Camera2Base";
+
+    private final Context context;
+    private Camera2ApiManager cameraManager;
+    protected VideoEncoder videoEncoder;
+    protected VideoEncoder videoEncoderRecord;
+    private MicrophoneManager microphoneManager;
+    private AudioEncoder audioEncoder;
+    private boolean streaming = false;
+    private GlInterface glInterface;
+    private boolean differentRecordResolution = false;
+    protected boolean audioInitialized = false;
+    private boolean onPreview = false;
+    private boolean isBackground = false;
+    protected RecordController recordController;
+    private int previewWidth, previewHeight;
+    private final FpsListener fpsListener = new FpsListener();
+
+    public Camera2Base(OpenGlView openGlView) {
+        context = openGlView.getContext();
+        glInterface = openGlView;
+        init(context);
+    }
+
+    public Camera2Base(Context context) {
+        this.context = context;
+        glInterface = new GlStreamInterface(context);
+        isBackground = true;
+        init(context);
+    }
+
+    private void init(Context context) {
+        cameraManager = new Camera2ApiManager(context);
+        microphoneManager = new MicrophoneManager(getMicrophoneData);
+        videoEncoder = new VideoEncoder(getVideoData);
+        videoEncoderRecord = new VideoEncoder(getVideoDataRecord);
+        audioEncoder = new AudioEncoder(getAudioData);
+        recordController = new AndroidMuxerRecordController();
+    }
+
+    public void setCameraCallbacks(CameraCallbacks callbacks) {
+        cameraManager.setCameraCallbacks(callbacks);
+    }
+
+    /**
+     * Set the mode to calculate timestamp. By default CLOCK.
+     * Must be called before startRecord/startStream or it will be ignored.
+     */
+    public void setTimestampMode(TimestampMode timestampModeVideo, TimestampMode timestampModeAudio) {
+        videoEncoder.setTimestampMode(timestampModeVideo);
+        videoEncoderRecord.setTimestampMode(timestampModeVideo);
+        audioEncoder.setTimestampMode(timestampModeAudio);
+    }
+
+    /**
+     * Set a callback to know errors related with Video/Audio encoders
+     * @param encoderErrorCallback callback to use, null to remove
+     */
+    public void setEncoderErrorCallback(CodecErrorCallback encoderErrorCallback) {
+        videoEncoder.setEncoderErrorCallback(encoderErrorCallback);
+        videoEncoderRecord.setEncoderErrorCallback(encoderErrorCallback);
+        audioEncoder.setEncoderErrorCallback(encoderErrorCallback);
+    }
+
+    /**
+     * Set an audio effect modifying microphone's PCM buffer.
+     */
+    public void setCustomAudioEffect(CustomAudioEffect customAudioEffect) {
+        microphoneManager.setCustomAudioEffect(customAudioEffect);
+    }
+
+    /**
+     * @param callback get fps while record or stream
+     */
+    public void setFpsListener(FpsListener.Callback callback) {
+        fpsListener.setCallback(callback);
+    }
+
+    /**
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableFaceDetection(FaceDetectorCallback faceDetectorCallback) {
+        return cameraManager.enableFaceDetection(faceDetectorCallback);
+    }
+
+    public void enableFrameCaptureCallback(FrameCapturedCallback frameCapturedCallback) {
+        cameraManager.enableFrameCaptureCallback(frameCapturedCallback);
+    }
+
+    public void disableFaceDetection() {
+        cameraManager.disableFaceDetection();
+    }
+
+    public boolean isFaceDetectionEnabled() {
+        return cameraManager.isFaceDetectionEnabled();
+    }
+
+    public boolean enableAutoExposure() {
+        return cameraManager.enableAutoExposure();
+    }
+
+    public void disableAutoExposure() {
+        cameraManager.disableAutoExposure();
+    }
+
+    public boolean isAutoExposureEnabled() {
+        return cameraManager.isAutoExposureEnabled();
+    }
+
+    /**
+     * Lock auto exposure to the current value. The camera will stop adjusting exposure
+     * automatically (useful to avoid exposure changes produced by faces or lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableExposureLock() {
+        return cameraManager.enableExposureLock();
+    }
+
+    public void disableExposureLock() {
+        cameraManager.disableExposureLock();
+    }
+
+    public boolean isExposureLockEnabled() {
+        return cameraManager.isExposureLockEnabled();
+    }
+
+    /**
+     * Lock auto white balance to the current value. The camera will stop adjusting white balance
+     * automatically (useful to avoid color shifts from lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableWhiteBalanceLock() {
+        return cameraManager.enableWhiteBalanceLock();
+    }
+
+    public void disableWhiteBalanceLock() {
+        cameraManager.disableWhiteBalanceLock();
+    }
+
+    public boolean isWhiteBalanceLockEnabled() {
+        return cameraManager.isWhiteBalanceLockEnabled();
+    }
+
+    public void setDynamicFps(boolean enabled) {
+        cameraManager.setDynamicFps(enabled);
+    }
+
+    /**
+     * Enable EIS video stabilization
+     * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableVideoStabilization() {
+        return cameraManager.enableVideoStabilization();
+    }
+
+    public void disableVideoStabilization() {
+        cameraManager.disableVideoStabilization();
+    }
+
+    public boolean isVideoStabilizationEnabled() {
+        return cameraManager.isVideoStabilizationEnabled();
+    }
+
+    /**
+     * Enable OIS video stabilization
+     * Warning: Turning both OIS and EIS modes on may produce undesirable interaction, so it is recommended not to enable both at the same time.
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableOpticalVideoStabilization() {
+        return cameraManager.enableOpticalVideoStabilization();
+    }
+
+    public void disableOpticalVideoStabilization() {
+        cameraManager.disableOpticalVideoStabilization();
+    }
+
+    public boolean isOpticalVideoStabilizationEnabled() {
+        return cameraManager.isOpticalStabilizationEnabled();
+    }
+
+    /**
+     * Use getCameraFacing instead
+     */
+    @Deprecated
+    public boolean isFrontCamera() {
+        return cameraManager.getCameraFacing() == CameraHelper.Facing.FRONT;
+    }
+
+    public CameraHelper.Facing getCameraFacing() {
+        return cameraManager.getCameraFacing();
+    }
+
+    public void enableLantern() throws Exception {
+        cameraManager.enableLantern();
+    }
+
+    public void disableLantern() {
+        cameraManager.disableLantern();
+    }
+
+    public boolean isLanternEnabled() {
+        return cameraManager.isLanternEnabled();
+    }
+
+    public boolean isLanternSupported() {
+        return cameraManager.isLanternSupported();
+    }
+
+    public boolean enableAutoFocus() {
+        return cameraManager.enableAutoFocus();
+    }
+
+    public boolean disableAutoFocus() {
+        return cameraManager.disableAutoFocus();
+    }
+
+    public boolean isAutoFocusEnabled() {
+        return cameraManager.isAutoFocusEnabled();
+    }
+
+    public void setFocusDistance(float distance) {
+        cameraManager.setFocusDistance(distance);
+    }
+
+    public String getCurrentCameraId() {
+        return cameraManager.getCurrentCameraId();
+    }
+
+    public boolean resetVideoEncoder() {
+        if (differentRecordResolution) {
+            glInterface.removeMediaCodecRecordSurface();
+            boolean result = videoEncoderRecord.reset();
+            if (!result) return false;
+            glInterface.addMediaCodecRecordSurface(videoEncoderRecord.getInputSurface());
+        }
+        glInterface.removeMediaCodecSurface();
+        boolean result = videoEncoder.reset();
+        if (!result) return false;
+        glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
+        return true;
+    }
+
+    public boolean resetAudioEncoder() {
+        return audioEncoder.reset();
+    }
+
+    /**
+     * Call this method before use @startStream. If not you will do a stream without video.
+     *
+     * @param width resolution in px.
+     * @param height resolution in px.
+     * @param fps frames per second of the stream.
+     * @param bitrate H264 in bps.
+     * @param rotation could be 90, 180, 270 or 0 (Normally 0 if you are streaming in landscape or 90
+     * @param profile codec value from MediaCodecInfo.CodecProfileLevel class
+     * @param level codec value from MediaCodecInfo.CodecProfileLevel class
+     * if you are streaming in Portrait). This only affect to stream result. NOTE: Rotation with
+     * encoder is silence ignored in some devices.
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a H264 encoder).
+     */
+    public boolean prepareVideo(
+        int width, int height, int fps, int bitrate, int iFrameInterval,
+        int rotation, int profile, int level,
+        int recordWidth, int recordHeight, int recordBitrate
+    ) {
+        if (onPreview && (width != previewWidth || height != previewHeight
+                || fps != videoEncoder.getFps() || rotation != videoEncoder.getRotation())) {
+            stopPreview();
+        }
+        differentRecordResolution = false;
+        if (recordWidth != width && recordHeight != height) {
+            if ((double) recordWidth / (double) recordHeight != (double) width / (double) height) {
+                Log.e(TAG, "The aspect ratio of record and stream resolution must be the same");
+                return false;
+            }
+            differentRecordResolution = true;
+        }
+        if (differentRecordResolution) {
+            boolean result = videoEncoderRecord.prepareVideoEncoder(recordWidth, recordHeight, fps, recordBitrate, rotation,
+                iFrameInterval, FormatVideoEncoder.SURFACE, profile, level);
+            if (!result) return false;
+        }
+        return videoEncoder.prepareVideoEncoder(width, height, fps, bitrate, rotation,
+                iFrameInterval, FormatVideoEncoder.SURFACE, profile, level);
+    }
+
+    public boolean prepareVideo(
+        int width, int height, int fps, int bitrate, int iFrameInterval,
+        int rotation, int profile, int level
+    ) {
+        return prepareVideo(width, height, fps, bitrate, iFrameInterval, rotation, profile, level, width, height, bitrate);
+    }
+
+    public boolean prepareVideo(int width, int height, int fps, int bitrate, int iFrameInterval,
+                                int rotation) {
+        return prepareVideo(width, height, fps, bitrate, iFrameInterval, rotation, -1, -1);
+    }
+
+    /**
+     * backward compatibility reason
+     */
+    public boolean prepareVideo(int width, int height, int fps, int bitrate, int rotation) {
+        return prepareVideo(width, height, fps, bitrate, 2, rotation);
+    }
+
+    public boolean prepareVideo(int width, int height, int bitrate) {
+        int rotation = CameraHelper.getCameraOrientation(context);
+        return prepareVideo(width, height, 30, bitrate, 2, rotation);
+    }
+
+    protected abstract void onAudioInfoImp(boolean isStereo, int sampleRate);
+
+    /**
+     * Call this method before use @startStream. If not you will do a stream without audio.
+     *
+     * @param bitrate AAC in kb.
+     * @param sampleRate of audio in hz. Can be 8000, 16000, 22500, 32000, 44100.
+     * @param isStereo true if you want Stereo audio (2 audio channels), false if you want Mono audio
+     * (1 audio channel).
+     * @param echoCanceler true enable echo canceler, false disable.
+     * @param noiseSuppressor true enable noise suppressor, false  disable.
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a AAC encoder).
+     */
+    public boolean prepareAudio(int audioSource, int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
+                                boolean noiseSuppressor) {
+        if (!microphoneManager.createMicrophone(audioSource, sampleRate, isStereo, echoCanceler, noiseSuppressor)) {
+            return false;
+        }
+        onAudioInfoImp(isStereo, sampleRate);
+        audioInitialized = audioEncoder.prepareAudioEncoder(bitrate, sampleRate, isStereo);
+        return audioInitialized;
+    }
+
+    public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo, boolean echoCanceler,
+                                boolean noiseSuppressor) {
+        return prepareAudio(MediaRecorder.AudioSource.DEFAULT, bitrate, sampleRate, isStereo, echoCanceler,
+                noiseSuppressor);
+    }
+
+    public boolean prepareAudio(int bitrate, int sampleRate, boolean isStereo) {
+        return prepareAudio(bitrate, sampleRate, isStereo, false, false);
+    }
+
+    /**
+     * Same to call: isHardwareRotation = true; if (openGlVIew) isHardwareRotation = false;
+     * prepareVideo(640, 480, 30, 1200 * 1024, isHardwareRotation, 90);
+     *
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a H264 encoder).
+     */
+    public boolean prepareVideo() {
+        int rotation = CameraHelper.getCameraOrientation(context);
+        return prepareVideo(640, 480, 30, 1200 * 1024, rotation);
+    }
+
+    /**
+     * Same to call: prepareAudio(64 * 1024, 32000, true, false, false);
+     *
+     * @return true if success, false if you get a error (Normally because the encoder selected
+     * doesn't support any configuration seated or your device hasn't a AAC encoder).
+     */
+    public boolean prepareAudio() {
+        return prepareAudio(64 * 1024, 32000, true, false, false);
+    }
+
+    /**
+     * @param codecTypeVideo force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
+     * @param codecTypeAudio force type codec used. FIRST_COMPATIBLE_FOUND, SOFTWARE, HARDWARE
+     */
+    public void forceCodecType(CodecUtil.CodecType codecTypeVideo, CodecUtil.CodecType codecTypeAudio) {
+        videoEncoder.forceCodecType(codecTypeVideo);
+        videoEncoderRecord.forceCodecType(codecTypeVideo);
+        audioEncoder.forceCodecType(codecTypeAudio);
+    }
+
+    /**
+     * Starts recording a MP4 video.
+     *
+     * @param path Where file will be saved.
+     * @throws IOException If initialized before a stream.
+     */
+    public void startRecord(@NonNull String path, @Nullable RecordController.Listener listener)
+            throws IOException {
+        RecordController.RecordTracks tracks = audioInitialized ?
+                RecordController.RecordTracks.ALL : RecordController.RecordTracks.VIDEO;
+        recordController.setRequestKeyFrame(this::requestKeyFrame);
+        recordController.startRecord(path, listener, tracks);
+        if (!streaming) startEncoders();
+    }
+
+    public void startRecord(@NonNull final String path) throws IOException {
+        startRecord(path, null);
+    }
+
+    /**
+     * Starts recording a MP4 video.
+     *
+     * @param fd Where the file will be saved.
+     * @throws IOException If initialized before a stream.
+     */
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void startRecord(@NonNull final FileDescriptor fd,
+                            @Nullable RecordController.Listener listener) throws IOException {
+        RecordController.RecordTracks tracks = audioInitialized ?
+                RecordController.RecordTracks.ALL : RecordController.RecordTracks.VIDEO;
+        recordController.setRequestKeyFrame(this::requestKeyFrame);
+        recordController.startRecord(fd, listener, tracks);
+        if (!streaming) startEncoders();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.O)
+    public void startRecord(@NonNull final FileDescriptor fd) throws IOException {
+        startRecord(fd, null);
+    }
+
+    /**
+     * Stop record MP4 video started with @startRecord. If you don't call it file will be unreadable.
+     */
+    public void stopRecord() {
+        recordController.stopRecord();
+        if (!streaming) stopStream();
+    }
+
+    public void replaceView(Context context) {
+        isBackground = true;
+        replaceGlInterface(new GlStreamInterface(context));
+    }
+
+    public void replaceView(OpenGlView openGlView) {
+        isBackground = false;
+        replaceGlInterface(openGlView);
+    }
+
+    /**
+     * Replace glInterface used on fly. Ignored if you use SurfaceView, TextureView or context without
+     * OpenGl.
+     */
+    private void replaceGlInterface(GlInterface glInterface) {
+        if (isStreaming() || isRecording() || isOnPreview()) {
+            Point size = this.glInterface.getEncoderSize();
+            Point sizeRecord = this.glInterface.getEncoderSize();
+            cameraManager.closeCamera();
+            this.glInterface.removeMediaCodecSurface();
+            this.glInterface.removeMediaCodecRecordSurface();
+            this.glInterface.stop();
+            this.glInterface = glInterface;
+            int w = size.x;
+            int h = size.y;
+            int recordW = sizeRecord.x;
+            int recordH = sizeRecord.y;
+            int rotation = videoEncoder.getRotation();
+            if (rotation == 90 || rotation == 270) {
+                h = size.x;
+                w = size.y;
+                recordH = sizeRecord.x;
+                recordW = sizeRecord.y;
+            }
+            prepareGlView(w, h, recordW, recordH, rotation);
+            cameraManager.openLastCamera();
+        } else {
+            this.glInterface = glInterface;
+        }
+    }
+
+    /**
+     * Start camera preview. Ignored, if stream or preview is started.
+     *
+     * @param cameraFacing front or back camera. Like: {@link com.pedro.encoder.input.video.CameraHelper.Facing#BACK}
+     * {@link com.pedro.encoder.input.video.CameraHelper.Facing#FRONT}
+     * @param rotation camera rotation (0, 90, 180, 270). Recommended: {@link
+     * com.pedro.encoder.input.video.CameraHelper#getCameraOrientation(Context)}
+     */
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int fps, int rotation) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing), width, height, fps, rotation);
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height, int rotation) {
+        startPreview(cameraFacing, width, height, videoEncoder.getFps(), rotation);
+    }
+
+    public void startPreview(String cameraId, int width, int height, int rotation) {
+        startPreview(cameraId, width, height, videoEncoder.getFps(), rotation);
+    }
+
+    public void startPreview(String cameraId, int width, int height, int fps, int rotation) {
+        if (!onPreview && !isBackground) {
+            previewWidth = width;
+            previewHeight = height;
+            videoEncoder.setFps(fps);
+            videoEncoder.setRotation(rotation);
+            videoEncoderRecord.setFps(fps);
+            videoEncoderRecord.setRotation(rotation);
+            prepareGlView(width, height, width, height, rotation);
+            cameraManager.openCameraId(cameraId);
+            onPreview = true;
+        } else if (!isStreaming() && !onPreview && isBackground) {
+            // if you are using background mode startPreview only work to indicate
+            // that you want start with front or back camera
+            cameraManager.setCameraId(cameraId);
+        } else {
+            Log.e(TAG, "Streaming or preview started, ignored");
+        }
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int width, int height) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                width, height, CameraHelper.getCameraOrientation(context));
+    }
+
+    public void startPreview(String cameraId, int width, int height) {
+        startPreview(cameraId, width, height, CameraHelper.getCameraOrientation(context));
+    }
+
+    public void startPreview(String cameraId, int rotation) {
+        startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing, int rotation) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                videoEncoder.getWidth(), videoEncoder.getHeight(), rotation);
+    }
+
+    public void startPreview(String cameraId) {
+        startPreview(cameraId, videoEncoder.getWidth(), videoEncoder.getHeight());
+    }
+
+    public void startPreview(CameraHelper.Facing cameraFacing) {
+        startPreview(cameraManager.getCameraIdForFacing(cameraFacing),
+                videoEncoder.getWidth(), videoEncoder.getHeight());
+    }
+
+    public void startPreview(int width, int height) {
+        startPreview(getCameraFacing(), width, height);
+    }
+
+    public void startPreview() {
+        startPreview(getCameraFacing());
+    }
+
+    /**
+     * Stop camera preview. Ignored if streaming or already stopped. You need call it after
+     *
+     * @stopStream to release camera properly if you will close activity.
+     */
+    public void stopPreview() {
+        if (!isStreaming() && !isRecording() && !isBackground) {
+            stopCamera();
+        } else {
+            Log.e(TAG, "Streaming or preview stopped, ignored");
+        }
+    }
+
+    /**
+     * Similar to stopPreview but you can do it while streaming or recording.
+     */
+    public void stopCamera() {
+        if (onPreview) {
+            glInterface.stop();
+            cameraManager.closeCamera();
+            onPreview = false;
+            previewWidth = 0;
+            previewHeight = 0;
+        } else {
+            Log.e(TAG, "Preview stopped, ignored");
+        }
+    }
+
+    public void startStreamAndRecord(String url, String path, RecordController.Listener listener) throws IOException {
+        startStream(url);
+        RecordController.RecordTracks tracks = audioInitialized ?
+                RecordController.RecordTracks.ALL : RecordController.RecordTracks.VIDEO;
+        recordController.setRequestKeyFrame(this::requestKeyFrame);
+        recordController.startRecord(path, listener, tracks);
+    }
+
+    public void startStreamAndRecord(String url, String path) throws IOException {
+        startStreamAndRecord(url, path, null);
+    }
+
+    protected abstract void startStreamImp(String url);
+
+    /**
+     * Need be called after @prepareVideo or/and @prepareAudio. This method override resolution of
+     *
+     * @param url of the stream like: protocol://ip:port/application/streamName
+     *
+     * RTSP: rtsp://192.168.1.1:1935/live/pedroSG94 RTSPS: rtsps://192.168.1.1:1935/live/pedroSG94
+     * RTMP: rtmp://192.168.1.1:1935/live/pedroSG94 RTMPS: rtmps://192.168.1.1:1935/live/pedroSG94
+     * @startPreview to resolution seated in @prepareVideo. If you never startPreview this method
+     * startPreview for you to resolution seated in @prepareVideo.
+     */
+    public void startStream(String url) {
+        streaming = true;
+        if (!recordController.isRunning()) {
+            startEncoders();
+        } else {
+            requestKeyFrame();
+        }
+        startStreamImp(url);
+        onPreview = true;
+    }
+
+    private void startEncoders() {
+        long startTs = TimeUtils.getCurrentTimeMicro();
+        videoEncoder.start(startTs);
+        if (differentRecordResolution) videoEncoderRecord.start(startTs);
+        if (audioInitialized) audioEncoder.start(startTs);
+        prepareGlView(videoEncoder.getWidth(), videoEncoder.getHeight(), videoEncoderRecord.getWidth(), videoEncoderRecord.getHeight(), videoEncoder.getRotation());
+        if (audioInitialized) microphoneManager.start();
+        if (!cameraManager.isRunning()) cameraManager.openLastCamera();
+        onPreview = true;
+    }
+
+    public void requestKeyFrame() {
+        if (videoEncoder.isRunning()) {
+            videoEncoder.requestKeyframe();
+        }
+        if (videoEncoderRecord.isRunning()) {
+            videoEncoderRecord.requestKeyframe();
+        }
+    }
+
+    private void prepareGlView(int width, int height, int recordWidth, int recordHeight, int rotation) {
+        int w = width;
+        int h = height;
+        int recordW = recordWidth;
+        int recordH = recordHeight;
+        boolean isPortrait = false;
+        if (rotation == 90 || rotation == 270) {
+            h = width;
+            w = height;
+            recordH = recordWidth;
+            recordW = recordHeight;
+            isPortrait = true;
+        }
+        glInterface.setEncoderSize(w, h);
+        if (differentRecordResolution) glInterface.setEncoderRecordSize(recordW, recordH);
+        if (glInterface instanceof GlStreamInterface glStreamInterface) {
+            glStreamInterface.setPreviewResolution(w, h);
+            glStreamInterface.setIsPortrait(isPortrait);
+        }
+        glInterface.setRotation(rotation == 0 ? 270 : rotation - 90);
+        if (!glInterface.isRunning()) glInterface.start();
+        if (videoEncoder.getInputSurface() != null && videoEncoder.isRunning()) {
+            glInterface.addMediaCodecSurface(videoEncoder.getInputSurface());
+        }
+        if (videoEncoderRecord.getInputSurface() != null && videoEncoderRecord.isRunning()) {
+            glInterface.addMediaCodecRecordSurface(videoEncoderRecord.getInputSurface());
+        }
+        int cameraWidth = Math.max(videoEncoder.getWidth(), videoEncoderRecord.getWidth());
+        int cameraHeight = Math.max(videoEncoder.getHeight(), videoEncoderRecord.getHeight());
+        cameraManager.prepareCamera(glInterface.getSurfaceTexture(), cameraWidth, cameraHeight, videoEncoder.getFps());
+    }
+
+    protected abstract void stopStreamImp();
+
+    /**
+     * Stop stream started with @startStream.
+     */
+    public void stopStream() {
+        if (streaming) {
+            streaming = false;
+            stopStreamImp();
+        }
+        if (!recordController.isRecording()) {
+            onPreview = !isBackground;
+            if (audioInitialized) microphoneManager.stop();
+            glInterface.removeMediaCodecSurface();
+            glInterface.removeMediaCodecRecordSurface();
+            if (glInterface instanceof GlStreamInterface) {
+                glInterface.stop();
+                cameraManager.closeCamera();
+            }
+            videoEncoder.stop();
+            if (differentRecordResolution) videoEncoderRecord.stop();
+            if (audioInitialized) audioEncoder.stop();
+            recordController.resetFormats();
+        }
+    }
+
+    /**
+     * Get supported resolutions of back camera in px.
+     *
+     * @return list of resolutions supported by back camera
+     */
+    public List<Size> getResolutionsBack() {
+        return Arrays.asList(cameraManager.getCameraResolutionsBack());
+    }
+
+    /**
+     * Get supported resolutions of front camera in px.
+     *
+     * @return list of resolutions supported by front camera
+     */
+    public List<Size> getResolutionsFront() {
+        return Arrays.asList(cameraManager.getCameraResolutionsFront());
+    }
+
+    /**
+     * Get supported resolutions of cameraId in px.
+     *
+     * @return list of resolutions supported by cameraId
+     */
+    public List<Size> getResolutions(String cameraId) {
+        return Arrays.asList(cameraManager.getCameraResolutions(cameraId));
+    }
+
+    public List<Range<Integer>> getSupportedFps() {
+        return cameraManager.getSupportedFps(null, CameraHelper.Facing.BACK);
+    }
+
+    public List<Range<Integer>> getSupportedFps(Size size, CameraHelper.Facing facing) {
+        return cameraManager.getSupportedFps(size, facing);
+    }
+
+    /**
+     * Get supported properties of the camera
+     *
+     * @return CameraCharacteristics object
+     */
+    public CameraCharacteristics getCameraCharacteristics() {
+        return cameraManager.getCameraCharacteristics();
+    }
+
+    /**
+     * Mute microphone, can be called before, while and after stream.
+     */
+    public void disableAudio() {
+        microphoneManager.mute();
+    }
+
+    /**
+     * Enable a muted microphone, can be called before, while and after stream.
+     */
+    public void enableAudio() {
+        microphoneManager.unMute();
+    }
+
+    /**
+     * Get mute state of microphone.
+     *
+     * @return true if muted, false if enabled
+     */
+    public boolean isAudioMuted() {
+        return microphoneManager.isMuted();
+    }
+
+    /**
+     * Return zoom level range
+     *
+     * @return zoom level range
+     */
+    public Range<Float> getZoomRange() {
+        return cameraManager.getZoomRange();
+    }
+
+    /**
+     * Return current zoom level
+     *
+     * @return current zoom level
+     */
+    public float getZoom() {
+        return cameraManager.getZoom();
+    }
+
+    /**
+     * Set zoomIn or zoomOut to camera.
+     * Use this method if you use a zoom slider.
+     *
+     * @param level Expected to be >= 1 and <= max zoom level
+     * @see Camera2Base#getZoom()
+     */
+    public void setZoom(float level) {
+        cameraManager.setZoom(level);
+    }
+
+    /**
+     * Set zoomIn or zoomOut to camera.
+     *
+     * @param event motion event. Expected to get event.getPointerCount() > 1
+     */
+    public void setZoom(MotionEvent event) {
+        cameraManager.setZoom(event);
+    }
+
+    public void setZoom(MotionEvent event, float delta) {
+        cameraManager.setZoom(event, delta);
+    }
+
+    /**
+     * @Experimental
+     * @return optical zoom values available
+     */
+    public Float[] getOpticalZooms() {
+        return cameraManager.getOpticalZooms();
+    }
+
+    /**
+     * @Experimental
+     * @param level value provided by getOpticalZooms method
+     */
+    public void setOpticalZoom(float level) {
+        cameraManager.setOpticalZoom(level);
+    }
+
+    public int getBitrate() {
+        return videoEncoder.getBitRate();
+    }
+
+    public int getResolutionValue() {
+        return videoEncoder.getWidth() * videoEncoder.getHeight();
+    }
+
+    public int getStreamWidth() {
+        return videoEncoder.getWidth();
+    }
+
+    public int getStreamHeight() {
+        return videoEncoder.getHeight();
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    public List<String> physicalCamerasAvailable() {
+        return cameraManager.getPhysicalCamerasAvailable();
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    public void openPhysicalCamera(String id) {
+        cameraManager.openPhysicalCamera(id);
+    }
+
+    /**
+     * @return IDs of cameras available that can be used on startPreview of switchCamera. null If no cameras available
+     */
+    public String[] getCamerasAvailable() {
+        return cameraManager.getCamerasAvailable();
+    }
+    /**
+     * Switch camera used. Can be called anytime
+     *
+     * @throws CameraOpenException If the other camera doesn't support same resolution.
+     */
+    public void switchCamera() throws CameraOpenException {
+        if (isStreaming() || isRecording() || onPreview) {
+            cameraManager.switchCamera();
+        } else {
+            cameraManager.setCameraFacing(getCameraFacing() == CameraHelper.Facing.FRONT ? CameraHelper.Facing.BACK : CameraHelper.Facing.FRONT);
+        }
+    }
+
+    /**
+     * Choose a specific camera to use. Can be called anytime.
+     *
+     * @param cameraId Identifier of the camera to use.
+     * @throws CameraOpenException
+     */
+    public void switchCamera(String cameraId) throws CameraOpenException {
+        if (isStreaming() || onPreview) {
+            cameraManager.reOpenCamera(cameraId);
+        } else {
+            cameraManager.setCameraId(cameraId);
+        }
+    }
+
+    public void setExposure(int value) {
+        cameraManager.setExposure(value);
+    }
+
+    public int getExposure() {
+        return cameraManager.getExposure();
+    }
+
+    public int getMaxExposure() {
+        return cameraManager.getMaxExposure();
+    }
+
+    public int getMinExposure() {
+        return cameraManager.getMinExposure();
+    }
+
+    public void forceBt709Color(boolean enabled) {
+      videoEncoder.forceBt709Color(enabled);
+    }
+
+    /**
+     * @param mode value from CameraCharacteristics.AWB_MODE_*
+     */
+    public boolean enableAutoWhiteBalance(int mode) {
+        return cameraManager.enableAutoWhiteBalance(mode);
+    }
+
+    public void disableAutoWhiteBalance() {
+        cameraManager.disableAutoWhiteBalance();
+    }
+
+    public boolean isAutoWhiteBalanceEnabled() {
+        return cameraManager.isAutoWhiteBalanceEnabled();
+    }
+
+    public int getWhiteBalance() {
+        return cameraManager.getWhiteBalance();
+    }
+
+    public List<Integer> getAutoWhiteBalanceModesAvailable() {
+        return cameraManager.getAutoWhiteBalanceModesAvailable();
+    }
+
+    public boolean setColorCorrectionGains(float red, float greenEven, float greenOdd, float blue) {
+        return cameraManager.setColorCorrectionGains(red, greenEven, greenOdd, blue);
+    }
+
+    public boolean tapToFocus(View view, MotionEvent event) {
+        return cameraManager.tapToFocus(view, event);
+    }
+
+    public boolean tapToMeterExposure(View view, MotionEvent event) {
+        return cameraManager.tapToMeterExposure(view, event);
+    }
+
+    public boolean tapToMeterWhiteBalance(View view, MotionEvent event) {
+        return cameraManager.tapToMeterWhiteBalance(view, event);
+    }
+
+    public GlInterface getGlInterface() {
+        return glInterface;
+    }
+
+    /**
+     * Set video bitrate of H264 in bits per second while stream.
+     *
+     * @param bitrate H264 in bits per second.
+     */
+    public void setVideoBitrateOnFly(int bitrate) {
+        videoEncoder.setVideoBitrateOnFly(bitrate);
+    }
+
+    /**
+     * Force stream to work with fps selected in prepareVideo method. Must be called before prepareVideo.
+     * This is not recommend because could produce fps problems.
+     *
+     * @param enabled true to enabled, false to disable, disabled by default.
+     */
+    public void forceFpsLimit(boolean enabled) {
+        int fps = enabled ? videoEncoder.getFps() : 0;
+        videoEncoder.setForceFps(fps);
+        videoEncoderRecord.setForceFps(fps);
+        glInterface.forceFpsLimit(fps);
+    }
+
+    /**
+     * Get stream state.
+     *
+     * @return true if streaming, false if not streaming.
+     */
+    public boolean isStreaming() {
+        return streaming;
+    }
+
+    /**
+     * Get record state.
+     *
+     * @return true if recording, false if not recoding.
+     */
+    public boolean isRecording() {
+        return recordController.isRunning();
+    }
+
+    public void pauseRecord() {
+        recordController.pauseRecord();
+    }
+
+    public void resumeRecord() {
+        recordController.resumeRecord();
+    }
+
+    public RecordController.Status getRecordStatus() {
+        return recordController.getStatus();
+    }
+
+    public void addImageListener(int width, int height, int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
+        cameraManager.addImageListener(width, height, format, maxImages, true, listener);
+    }
+
+    public void addImageListener(int width, int height, int format, int maxImages, boolean autoClose, Camera2ApiManager.ImageCallback listener) {
+        cameraManager.addImageListener(width, height, format, maxImages, autoClose, listener);
+    }
+
+    public void addImageListener(int format, int maxImages, Camera2ApiManager.ImageCallback listener) {
+        if (videoEncoder.getRotation() == 90 || videoEncoder.getRotation() == 270) {
+            addImageListener(videoEncoder.getHeight(), videoEncoder.getWidth(), format, maxImages, listener);
+        } else {
+            addImageListener(videoEncoder.getWidth(), videoEncoder.getHeight(), format, maxImages, listener);
+        }
+    }
+
+    public void removeImageListener() {
+        cameraManager.removeImageListener();
+    }
+    /**
+     * Get preview state.
+     *
+     * @return true if enabled, false if disabled.
+     */
+    public boolean isOnPreview() {
+        return onPreview;
+    }
+
+    protected abstract void getAudioDataImp(ByteBuffer audioBuffer, MediaCodec.BufferInfo info);
+
+    protected abstract void onVideoInfoImp(ByteBuffer sps, ByteBuffer pps, ByteBuffer vps);
+
+    protected abstract void getVideoDataImp(ByteBuffer videoBuffer, MediaCodec.BufferInfo info);
+
+    public void setRecordController(RecordController recordController) {
+        if (!isRecording()) {
+            recordController.updateInfo(this.recordController.getVideoCodec(), this.recordController.getAudioCodec());
+            this.recordController = recordController;
+        }
+    }
+
+    private final GetMicrophoneData getMicrophoneData = frame -> {
+        audioEncoder.inputPCMData(frame);
+    };
+
+    private final GetAudioData getAudioData = new GetAudioData() {
+        @Override
+        public void getAudioData(@NonNull ByteBuffer audioBuffer, @NonNull MediaCodec.BufferInfo info) {
+            recordController.recordAudio(audioBuffer, info);
+            if (streaming) getAudioDataImp(audioBuffer, info);
+        }
+
+        @Override
+        public void onAudioFormat(@NonNull MediaFormat mediaFormat) {
+            recordController.setAudioFormat(mediaFormat);
+        }
+    };
+
+    private final GetVideoData getVideoData = new GetVideoData() {
+        @Override
+        public void onVideoInfo(@NonNull ByteBuffer sps, @Nullable ByteBuffer pps, @Nullable ByteBuffer vps) {
+            onVideoInfoImp(sps.duplicate(),  pps != null ? pps.duplicate(): null, vps != null ? vps.duplicate() : null);
+        }
+
+        @Override
+        public void getVideoData(@NonNull ByteBuffer videoBuffer, @NonNull MediaCodec.BufferInfo info) {
+            fpsListener.calculateFps();
+            if (!differentRecordResolution) recordController.recordVideo(videoBuffer, info);
+            if (streaming) getVideoDataImp(videoBuffer, info);
+        }
+
+        @Override
+        public void onVideoFormat(@NonNull MediaFormat mediaFormat) {
+            if (!differentRecordResolution) recordController.setVideoFormat(mediaFormat);
+        }
+    };
+
+    private final GetVideoData getVideoDataRecord = new GetVideoData() {
+        @Override
+        public void onVideoInfo(@NonNull ByteBuffer sps, @Nullable ByteBuffer pps, @Nullable ByteBuffer vps) {
+        }
+
+        @Override
+        public void getVideoData(@NonNull ByteBuffer videoBuffer, @NonNull MediaCodec.BufferInfo info) {
+            recordController.recordVideo(videoBuffer, info);
+        }
+
+        @Override
+        public void onVideoFormat(@NonNull MediaFormat mediaFormat) {
+            recordController.setVideoFormat(mediaFormat);
+        }
+    };
+
+    public abstract StreamBaseClient getStreamClient();
+
+    public void setVideoCodec(VideoCodec codec) {
+        setVideoCodecImp(codec);
+        recordController.setVideoCodec(codec);
+        videoEncoder.type = codec;
+    }
+
+    public void setAudioCodec(AudioCodec codec) {
+        setAudioCodecImp(codec);
+        recordController.setAudioCodec(codec);
+        audioEncoder.type = codec;
+    }
+
+    protected abstract void setVideoCodecImp(VideoCodec codec);
+    protected abstract void setAudioCodecImp(AudioCodec codec);
+}

--- a/Camera2Source.kt
+++ b/Camera2Source.kt
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2024 pedroSG94.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.pedro.encoder.input.sources.video
+
+import android.content.Context
+import android.graphics.SurfaceTexture
+import android.hardware.camera2.CameraCaptureSession
+import android.hardware.camera2.CameraCharacteristics
+import android.hardware.camera2.CameraManager
+import android.hardware.camera2.CaptureRequest
+import android.hardware.camera2.TotalCaptureResult
+import android.os.Build
+import android.util.Range
+import android.util.Size
+import android.view.MotionEvent
+import android.view.View
+import androidx.annotation.RequiresApi
+import com.pedro.encoder.input.video.Camera2ApiManager
+import com.pedro.encoder.input.video.Camera2ApiManager.ImageCallback
+import com.pedro.encoder.input.video.CameraCallbacks
+import com.pedro.encoder.input.video.CameraHelper
+import com.pedro.encoder.input.video.FrameCapturedCallback
+import com.pedro.encoder.input.video.facedetector.FaceDetectorCallback
+
+/**
+ * Created by pedro on 11/1/24.
+ */
+@RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+class Camera2Source(context: Context): VideoSource() {
+
+  private val camera = Camera2ApiManager(context)
+  private var facing = CameraHelper.Facing.BACK
+
+  override fun create(width: Int, height: Int, fps: Int, rotation: Int): Boolean {
+    val result = checkResolutionSupported(width, height)
+    if (!result) {
+      throw IllegalArgumentException("Unsupported resolution: ${width}x$height")
+    }
+    return true
+  }
+
+  override fun start(surfaceTexture: SurfaceTexture) {
+    this.surfaceTexture = surfaceTexture
+    if (isRunning()) return
+    surfaceTexture.setDefaultBufferSize(width, height)
+    camera.prepareCamera(surfaceTexture, width, height, fps, facing)
+    camera.openCameraFacing(facing)
+  }
+
+  override fun stop() {
+    camera.closeCamera()
+  }
+
+  override fun release() {}
+
+  override fun isRunning(): Boolean = camera.isRunning
+
+  private fun checkResolutionSupported(width: Int, height: Int): Boolean {
+    if (width % 2 != 0 || height % 2 != 0) {
+      throw IllegalArgumentException("width and height values must be divisible by 2")
+    }
+    val size = Size(width, height)
+    val resolutions = if (facing == CameraHelper.Facing.BACK) {
+      camera.cameraResolutionsBack
+    } else camera.cameraResolutionsFront
+    return if (camera.levelSupported == CameraCharacteristics.INFO_SUPPORTED_HARDWARE_LEVEL_LEGACY) {
+      //this is a wrapper of camera1 api. Only listed resolutions are supported
+      resolutions.contains(size)
+    } else {
+      val widthList = resolutions.map { size.width }
+      val heightList = resolutions.map { size.height }
+      val maxWidth = widthList.maxOrNull() ?: 0
+      val maxHeight = heightList.maxOrNull() ?: 0
+      val minWidth = widthList.minOrNull() ?: 0
+      val minHeight = heightList.minOrNull() ?: 0
+      size.width in minWidth..maxWidth && size.height in minHeight..maxHeight
+    }
+  }
+
+  fun switchCamera() {
+    facing = if (facing == CameraHelper.Facing.BACK) {
+      CameraHelper.Facing.FRONT
+    } else {
+      CameraHelper.Facing.BACK
+    }
+    if (isRunning()) {
+      stop()
+      surfaceTexture?.let {
+        start(it)
+      }
+    }
+  }
+
+  fun getCameraFacing() = facing
+
+  fun getCameraResolutions(facing: CameraHelper.Facing): List<Size> {
+    val resolutions = if (facing == CameraHelper.Facing.FRONT) {
+      camera.cameraResolutionsFront
+    } else {
+      camera.cameraResolutionsBack
+    }
+    return resolutions.toList()
+  }
+
+  fun setExposure(level: Int) {
+    if (isRunning()) camera.exposure = level
+  }
+
+  fun getExposure(): Int {
+    return if (isRunning()) camera.exposure else 0
+  }
+
+  fun enableLantern() {
+    if (isRunning()) camera.enableLantern()
+  }
+
+  fun disableLantern() {
+    if (isRunning()) camera.disableLantern()
+  }
+
+  fun isLanternEnabled(): Boolean {
+    return if (isRunning()) camera.isLanternEnabled else false
+  }
+
+  fun enableAutoFocus(): Boolean {
+    if (isRunning()) return camera.enableAutoFocus()
+    return false
+  }
+
+  fun disableAutoFocus(): Boolean {
+    if (isRunning()) return camera.disableAutoFocus()
+    return false
+  }
+
+  fun isAutoFocusEnabled(): Boolean {
+    return if (isRunning()) camera.isAutoFocusEnabled else false
+  }
+
+  fun tapToFocus(view: View, event: MotionEvent): Boolean {
+    return camera.tapToFocus(view, event)
+  }
+
+  fun tapToMeterExposure(view: View, event: MotionEvent): Boolean {
+    return if (isRunning()) camera.tapToMeterExposure(view, event) else false
+  }
+
+  fun tapToMeterWhiteBalance(view: View, event: MotionEvent): Boolean {
+    return if (isRunning()) camera.tapToMeterWhiteBalance(view, event) else false
+  }
+
+  @JvmOverloads
+  fun setZoom(event: MotionEvent, delta: Float = 0.1f) {
+    if (isRunning()) camera.setZoom(event, delta)
+  }
+
+  fun setZoom(level: Float) {
+    if (isRunning()) camera.zoom = level
+  }
+
+  fun getZoomRange(): Range<Float> = camera.zoomRange
+
+  fun getZoom(): Float = camera.zoom
+
+  fun enableFaceDetection(callback: FaceDetectorCallback): Boolean {
+    return if (isRunning()) camera.enableFaceDetection(callback) else false
+  }
+
+  fun enableFrameCaptureCallback(frameCapturedCallback: FrameCapturedCallback?) {
+    camera.enableFrameCaptureCallback(frameCapturedCallback)
+  }
+
+  fun disableFaceDetection() {
+    if (isRunning()) camera.disableFaceDetection()
+  }
+
+  fun isFaceDetectionEnabled() = camera.isFaceDetectionEnabled()
+
+  fun camerasAvailable(): Array<String> = camera.camerasAvailable
+
+  fun getCurrentCameraId() = camera.getCurrentCameraId()
+
+  fun openCameraId(id: String) {
+    if (isRunning()) camera.reOpenCamera(id)
+  }
+
+  fun enableOpticalVideoStabilization(): Boolean {
+    return if (isRunning()) camera.enableOpticalVideoStabilization() else false
+  }
+
+  fun disableOpticalVideoStabilization() {
+    if (isRunning()) camera.disableOpticalVideoStabilization()
+  }
+
+  fun isOpticalVideoStabilizationEnabled() = camera.isOpticalStabilizationEnabled
+
+  fun enableVideoStabilization(): Boolean {
+    return if (isRunning()) camera.enableVideoStabilization() else false
+  }
+
+  fun disableVideoStabilization() {
+    if (isRunning()) camera.disableVideoStabilization()
+  }
+
+  fun isVideoStabilizationEnabled() = camera.isVideoStabilizationEnabled
+
+  fun enableAutoExposure(): Boolean {
+    return if (isRunning()) camera.enableAutoExposure() else false
+  }
+
+  fun disableAutoExposure() {
+    if (isRunning()) camera.disableAutoExposure()
+  }
+
+  fun isAutoExposureEnabled() = camera.isAutoExposureEnabled
+
+  /**
+   * Lock auto exposure to the current value. The camera will stop adjusting exposure
+   * automatically (useful to avoid exposure changes produced by faces or lighting changes).
+   * @return true if success, false if fail (not supported or called before start camera)
+   */
+  fun enableExposureLock(): Boolean {
+    return if (isRunning()) camera.enableExposureLock() else false
+  }
+
+  fun disableExposureLock() {
+    if (isRunning()) camera.disableExposureLock()
+  }
+
+  fun isExposureLockEnabled() = camera.isExposureLockEnabled
+
+  fun enableWhiteBalanceLock(): Boolean {
+    return if (isRunning()) camera.enableWhiteBalanceLock() else false
+  }
+
+  fun disableWhiteBalanceLock() {
+    if (isRunning()) camera.disableWhiteBalanceLock()
+  }
+
+  fun isWhiteBalanceLockEnabled() = camera.isWhiteBalanceLockEnabled
+
+  @JvmOverloads
+  fun addImageListener(
+    format: Int,
+    maxImages: Int,
+    autoClose: Boolean = true,
+    listener: ImageCallback
+  ) {
+    val w = if (rotation == 90 || rotation == 270) height else width
+    val h = if (rotation == 90 || rotation == 270) width else height
+    camera.addImageListener(w, h, format, maxImages, autoClose, listener)
+  }
+
+  fun removeImageListener() {
+    camera.removeImageListener()
+  }
+
+  @RequiresApi(Build.VERSION_CODES.P)
+  fun physicalCamerasAvailable() = camera.getPhysicalCamerasAvailable()
+
+  @RequiresApi(Build.VERSION_CODES.P)
+  fun openPhysicalCamera(id: String?) {
+    camera.openPhysicalCamera(id)
+  }
+
+  fun setCameraCallback(callbacks: CameraCallbacks?) {
+    camera.setCameraCallbacks(callbacks)
+  }
+
+  /**
+   * @param mode value from CameraCharacteristics.AWB_MODE_*
+   */
+  fun enableAutoWhiteBalance(mode: Int) = camera.enableAutoWhiteBalance(mode)
+
+  fun disableAutoWhiteBalance() {
+    camera.disableAutoWhiteBalance()
+  }
+
+  fun isAutoWhiteBalanceEnabled() = camera.isAutoWhiteBalanceEnabled
+
+  fun getWhiteBalance() = camera.getWhiteBalance()
+
+  fun getAutoWhiteBalanceModesAvailable() = camera.getAutoWhiteBalanceModesAvailable()
+
+  fun setColorCorrectionGains(red: Float, greenEven: Float, greenOdd: Float, blue: Float) =
+    camera.setColorCorrectionGains(red, greenEven, greenOdd, blue)
+
+  @JvmOverloads
+  fun getMaxSupportedFps(size: Size?, facing: CameraHelper.Facing = getCameraFacing()): Int {
+    return camera.getSupportedFps(size, facing).maxOfOrNull { it.upper } ?: 30
+  }
+
+  /**
+   * Set the required resolution for the camera.
+   * Must be called before prepareVideo or changeVideoSource. Otherwise it will be ignored.
+   */
+  fun setRequiredResolution(size: Size?) {
+    size?.let { checkResolutionSupported(it.width, it.height) }
+    camera.setRequiredResolution(size)
+  }
+
+  /**
+   * Add a callback to detect the camera availability.
+   * Set null value to remove the callback
+   */
+  fun setAvailabilityCallback(callback: CameraManager.AvailabilityCallback?) {
+    camera.setAvailabilityCallback(callback)
+  }
+
+  /**
+   * Re start camera if possible, return true or false depend if can do it or not.
+   */
+  fun restart(): Boolean {
+    if (isRunning()) camera.reOpenCamera(camera.getCurrentCameraId())
+    else if (camera.isPrepared) camera.openCameraId(camera.getCurrentCameraId())
+    else return false
+    return true
+  }
+
+  /**
+   * @return true of false depend if success or fail to do it.
+   *
+   * Set custom values to the camera.
+   * Need to be called after start or it will return false.
+   * Build and apply are done by the library automatically.
+   *
+   * For example, if you want disable autoExposure:
+   *
+   * camera.setCustomRequest { builder ->
+   *   builder.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_OFF)
+   * }
+   */
+  fun setCustomRequest(request: (CaptureRequest.Builder) -> Unit): Boolean {
+    return camera.setCustomRequest(request)
+  }
+
+  fun setCustomOnCaptureCompletedCallback(
+    callback: ((CameraCaptureSession, CaptureRequest, TotalCaptureResult) -> Unit)?
+  ) {
+    camera.setCustomOnCaptureCompletedCallback(callback)
+  }
+
+  fun setDynamicFps(enabled: Boolean) {
+    camera.dynamicFps = enabled
+  }
+}


### PR DESCRIPTION
## Summary

- Add white balance lock: `enableWhiteBalanceLock()` / `disableWhiteBalanceLock()` / `isWhiteBalanceLockEnabled()`.
- Add tap-to-meter: `tapToMeterExposure(view, event)` / `tapToMeterWhiteBalance(view, event)`.
- Exposed through `Camera2ApiManager`, `Camera2Source`, and `Camera2Base` (all Camera2 stream classes inherit via `Camera2Base`).

## Motivation

Upstream 2.8.0 added exposure lock (`enableExposureLock()` / `disableExposureLock()`), but there is no equivalent for white balance lock or tap-to-meter for AE/AWB regions. These are standard Camera2 capabilities used by live streaming apps that need manual exposure/WB control during broadcast (e.g. lock color after calibration, tap a region to meter before locking).

## API

| Method | Layer | Purpose |
|--------|-------|---------|
| `enableWhiteBalanceLock()` | Camera2ApiManager, Camera2Source, Camera2Base | Lock AWB via `CONTROL_AWB_LOCK` |
| `disableWhiteBalanceLock()` | same | Unlock AWB |
| `isWhiteBalanceLockEnabled()` | same | Query lock state |
| `tapToMeterExposure(view, event)` | same | Set AE metering region at touch point |
| `tapToMeterWhiteBalance(view, event)` | same | Set AWB metering region at touch point |

Naming follows existing upstream conventions:
- Lock APIs mirror `enableExposureLock()` / `disableExposureLock()` / `isExposureLockEnabled()`.
- Tap APIs mirror `tapToFocus()` with `tapToMeter*` prefix to distinguish metering from focus.

## Implementation notes

- **White balance lock** uses `CaptureRequest.CONTROL_AWB_LOCK`, same pattern as existing exposure lock.
- **Tap metering** maps view coordinates to sensor active array and sets a 200×200 `MeteringRectangle` (same size as `tapToFocus`). Returns `false` if the device reports zero AE/AWB regions.
- **State tracking** — `isWhiteBalanceLockEnabled` on `Camera2ApiManager`, consistent with `isExposureLockEnabled`.
