### PR TITLE
Add Camera2 white balance lock and tap-to-meter APIs

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/input/sources/video/Camera2Source.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/sources/video/Camera2Source.kt
@@ -154,6 +154,14 @@ class Camera2Source(context: Context): VideoSource() {
     return camera.tapToFocus(view, event)
   }
 
+  fun tapToMeterExposure(view: View, event: MotionEvent): Boolean {
+    return if (isRunning()) camera.tapToMeterExposure(view, event) else false
+  }
+
+  fun tapToMeterWhiteBalance(view: View, event: MotionEvent): Boolean {
+    return if (isRunning()) camera.tapToMeterWhiteBalance(view, event) else false
+  }
+
   @JvmOverloads
   fun setZoom(event: MotionEvent, delta: Float = 0.1f) {
     if (isRunning()) camera.setZoom(event, delta)
@@ -233,6 +241,16 @@ class Camera2Source(context: Context): VideoSource() {
   }
 
   fun isExposureLockEnabled() = camera.isExposureLockEnabled
+
+  fun enableWhiteBalanceLock(): Boolean {
+    return if (isRunning()) camera.enableWhiteBalanceLock() else false
+  }
+
+  fun disableWhiteBalanceLock() {
+    if (isRunning()) camera.disableWhiteBalanceLock()
+  }
+
+  fun isWhiteBalanceLockEnabled() = camera.isWhiteBalanceLockEnabled
 
   @JvmOverloads
   fun addImageListener(

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
@@ -500,7 +500,10 @@ class Camera2ApiManager(context: Context) {
      * @return true if success, false if fail (not supported or called before start camera)
      */
     fun enableWhiteBalanceLock(): Boolean {
+        val characteristics = cameraCharacteristics ?: return false
         val builderInputSurface = this.builderInputSurface ?: return false
+        val available = characteristics.secureGet(CameraCharacteristics.CONTROL_AWB_LOCK_AVAILABLE) ?: return false
+        if (!available) return false
         builderInputSurface.set(CaptureRequest.CONTROL_AWB_LOCK, true)
         isWhiteBalanceLockEnabled = applyRequest(builderInputSurface)
         return isWhiteBalanceLockEnabled

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
@@ -411,6 +411,11 @@ class Camera2ApiManager(context: Context) {
         val builderInputSurface = this.builderInputSurface ?: return false
         val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AWB_AVAILABLE_MODES) ?: return false
         if (!modes.contains(mode)) return false
+        val maxRegionsAwb = characteristics.secureGet(CameraCharacteristics.CONTROL_MAX_REGIONS_AWB) ?: 0
+        if (maxRegionsAwb > 0) {
+            val clearRect = MeteringRectangle(0, 0, 0, 0, MeteringRectangle.METERING_WEIGHT_DONT_CARE)
+            builderInputSurface.set(CaptureRequest.CONTROL_AWB_REGIONS, arrayOf(clearRect))
+        }
         builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, mode)
         isAutoWhiteBalanceEnabled = applyRequest(builderInputSurface)
         return isAutoWhiteBalanceEnabled
@@ -455,6 +460,11 @@ class Camera2ApiManager(context: Context) {
         val builderInputSurface = this.builderInputSurface ?: return false
         val modes = characteristics.secureGet(CameraCharacteristics.CONTROL_AE_AVAILABLE_MODES) ?: return false
         if (!modes.contains(CaptureRequest.CONTROL_AE_MODE_ON)) return false
+        val maxRegionsAe = characteristics.secureGet(CameraCharacteristics.CONTROL_MAX_REGIONS_AE) ?: 0
+        if (maxRegionsAe > 0) {
+            val clearRect = MeteringRectangle(0, 0, 0, 0, MeteringRectangle.METERING_WEIGHT_DONT_CARE)
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_REGIONS, arrayOf(clearRect))
+        }
         builderInputSurface.set(CaptureRequest.CONTROL_AE_MODE, CaptureRequest.CONTROL_AE_MODE_ON)
         isAutoExposureEnabled = applyRequest(builderInputSurface)
         return isAutoExposureEnabled

--- a/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
+++ b/encoder/src/main/java/com/pedro/encoder/input/video/Camera2ApiManager.kt
@@ -99,6 +99,8 @@ class Camera2ApiManager(context: Context) {
         private set
     var isAutoWhiteBalanceEnabled: Boolean = true
         private set
+    var isWhiteBalanceLockEnabled: Boolean = false
+        private set
     var isRunning: Boolean = false
         private set
     private var fps = 30
@@ -492,6 +494,25 @@ class Camera2ApiManager(context: Context) {
         isExposureLockEnabled = false
     }
 
+    /**
+     * Lock auto white balance to the current value. The camera will stop adjusting white balance
+     * automatically (useful to avoid color shifts from lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    fun enableWhiteBalanceLock(): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_LOCK, true)
+        isWhiteBalanceLockEnabled = applyRequest(builderInputSurface)
+        return isWhiteBalanceLockEnabled
+    }
+
+    fun disableWhiteBalanceLock() {
+        val builderInputSurface = this.builderInputSurface ?: return
+        builderInputSurface.set(CaptureRequest.CONTROL_AWB_LOCK, false)
+        applyRequest(builderInputSurface)
+        isWhiteBalanceLockEnabled = false
+    }
+
     fun enableVideoStabilization(): Boolean {
         val characteristics = cameraCharacteristics ?: return false
         val builderInputSurface = this.builderInputSurface ?: return false
@@ -618,6 +639,76 @@ class Camera2ApiManager(context: Context) {
             return true
         } catch (_: Exception) {
             return false
+        }
+    }
+
+    /**
+     * Tap to meter exposure at a specific point.
+     *
+     * @param view The view where the touch event occurred
+     * @param event The touch event containing coordinates
+     * @return true if successful, false otherwise
+     */
+    fun tapToMeterExposure(view: View, event: MotionEvent): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val characteristics = cameraCharacteristics ?: return false
+        if (characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AE) == 0) return false
+
+        val sensorArraySize = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return false
+        val regionX = (event.x / view.width.toFloat()) * sensorArraySize.width()
+        val regionY = (event.y / view.height.toFloat()) * sensorArraySize.height()
+
+        val aeRect = MeteringRectangle(
+            (regionX - 100).toInt().coerceIn(0, sensorArraySize.width()),
+            (regionY - 100).toInt().coerceIn(0, sensorArraySize.height()),
+            (100 * 2).coerceIn(0, sensorArraySize.width()),
+            (100 * 2).coerceIn(0, sensorArraySize.height()),
+            MeteringRectangle.METERING_WEIGHT_MAX
+        )
+
+        return try {
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_REGIONS, arrayOf(aeRect))
+            builderInputSurface.set(CaptureRequest.CONTROL_AE_MODE, CameraMetadata.CONTROL_AE_MODE_ON)
+            isAutoExposureEnabled = applyRequest(builderInputSurface)
+            isAutoExposureEnabled
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting AE region", e)
+            false
+        }
+    }
+
+    /**
+     * Tap to meter white balance at a specific point.
+     *
+     * @param view The view where the touch event occurred
+     * @param event The touch event containing coordinates
+     * @return true if successful, false otherwise
+     */
+    fun tapToMeterWhiteBalance(view: View, event: MotionEvent): Boolean {
+        val builderInputSurface = this.builderInputSurface ?: return false
+        val characteristics = cameraCharacteristics ?: return false
+        if (characteristics.get(CameraCharacteristics.CONTROL_MAX_REGIONS_AWB) == 0) return false
+
+        val sensorArraySize = characteristics.get(CameraCharacteristics.SENSOR_INFO_ACTIVE_ARRAY_SIZE) ?: return false
+        val regionX = (event.x / view.width.toFloat()) * sensorArraySize.width()
+        val regionY = (event.y / view.height.toFloat()) * sensorArraySize.height()
+
+        val awbRect = MeteringRectangle(
+            (regionX - 100).toInt().coerceIn(0, sensorArraySize.width()),
+            (regionY - 100).toInt().coerceIn(0, sensorArraySize.height()),
+            (100 * 2).coerceIn(0, sensorArraySize.width()),
+            (100 * 2).coerceIn(0, sensorArraySize.height()),
+            MeteringRectangle.METERING_WEIGHT_MAX
+        )
+
+        return try {
+            builderInputSurface.set(CaptureRequest.CONTROL_AWB_REGIONS, arrayOf(awbRect))
+            builderInputSurface.set(CaptureRequest.CONTROL_AWB_MODE, CameraMetadata.CONTROL_AWB_MODE_AUTO)
+            isAutoWhiteBalanceEnabled = applyRequest(builderInputSurface)
+            isAutoWhiteBalanceEnabled
+        } catch (e: Exception) {
+            Log.e(TAG, "Error setting AWB region", e)
+            false
         }
     }
 

--- a/library/src/main/java/com/pedro/library/base/Camera2Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera2Base.java
@@ -206,6 +206,23 @@ public abstract class Camera2Base {
         return cameraManager.isExposureLockEnabled();
     }
 
+    /**
+     * Lock auto white balance to the current value. The camera will stop adjusting white balance
+     * automatically (useful to avoid color shifts from lighting changes).
+     * @return true if success, false if fail (not supported or called before start camera)
+     */
+    public boolean enableWhiteBalanceLock() {
+        return cameraManager.enableWhiteBalanceLock();
+    }
+
+    public void disableWhiteBalanceLock() {
+        cameraManager.disableWhiteBalanceLock();
+    }
+
+    public boolean isWhiteBalanceLockEnabled() {
+        return cameraManager.isWhiteBalanceLockEnabled();
+    }
+
     public void setDynamicFps(boolean enabled) {
         cameraManager.setDynamicFps(enabled);
     }
@@ -979,6 +996,14 @@ public abstract class Camera2Base {
 
     public boolean tapToFocus(View view, MotionEvent event) {
         return cameraManager.tapToFocus(view, event);
+    }
+
+    public boolean tapToMeterExposure(View view, MotionEvent event) {
+        return cameraManager.tapToMeterExposure(view, event);
+    }
+
+    public boolean tapToMeterWhiteBalance(View view, MotionEvent event) {
+        return cameraManager.tapToMeterWhiteBalance(view, event);
     }
 
     public GlInterface getGlInterface() {


### PR DESCRIPTION
## Summary

- Add white balance lock: `enableWhiteBalanceLock()` / `disableWhiteBalanceLock()` / `isWhiteBalanceLockEnabled()`.
- Add tap-to-meter: `tapToMeterExposure(view, event)` / `tapToMeterWhiteBalance(view, event)`.
- Exposed through `Camera2ApiManager`, `Camera2Source`, and `Camera2Base` (all Camera2 stream classes inherit via `Camera2Base`).

## Motivation

Upstream 2.8.0 added exposure lock (`enableExposureLock()` / `disableExposureLock()`), but there is no equivalent for white balance lock or tap-to-meter for AE/AWB regions. These are standard Camera2 capabilities used by live streaming apps that need manual exposure/WB control during broadcast (e.g. lock color after calibration, tap a region to meter before locking).

## API

| Method | Layer | Purpose |
|--------|-------|---------|
| `enableWhiteBalanceLock()` | Camera2ApiManager, Camera2Source, Camera2Base | Lock AWB via `CONTROL_AWB_LOCK` |
| `disableWhiteBalanceLock()` | same | Unlock AWB |
| `isWhiteBalanceLockEnabled()` | same | Query lock state |
| `tapToMeterExposure(view, event)` | same | Set AE metering region at touch point |
| `tapToMeterWhiteBalance(view, event)` | same | Set AWB metering region at touch point |

Naming follows existing upstream conventions:
- Lock APIs mirror `enableExposureLock()` / `disableExposureLock()` / `isExposureLockEnabled()`.
- Tap APIs mirror `tapToFocus()` with `tapToMeter*` prefix to distinguish metering from focus.

## Implementation notes

- **White balance lock** uses `CaptureRequest.CONTROL_AWB_LOCK`, same pattern as existing exposure lock.
- **Tap metering** maps view coordinates to sensor active array and sets a 200×200 `MeteringRectangle` (same size as `tapToFocus`). Returns `false` if the device reports zero AE/AWB regions.
- **State tracking** — `isWhiteBalanceLockEnabled` on `Camera2ApiManager`, consistent with `isExposureLockEnabled`.
