### PR TITLE
Fix audio lagging video: rebase surface PTS on the shared start, not the first frame

### DIFF
--- a/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
+++ b/encoder/src/main/java/com/pedro/encoder/video/VideoEncoder.java
@@ -444,6 +444,30 @@ public class VideoEncoder extends BaseEncoder implements GetCameraData {
     spsPpsSetted = sendSPSandPPS(mediaFormat);
   }
 
+  /**
+   * Surface mode: the EGL timestamp is a huge absolute value that would break RTMP, so it has to be
+   * rebased to something relative. Rebase it against the start the encoders were given, not against
+   * this encoder's own first frame.
+   *
+   * GlStreamInterface stamps every frame through GlTimestamp, which anchors to TimeUtils — the same
+   * clock StreamBase reads to start both encoders — so subtracting presentTimeUs is meaningful and
+   * mirrors what AudioEncoder.calculatePts already does.
+   *
+   * Rebasing on the first frame instead put the two timelines on different zeros: audio counted from
+   * the moment the stream started, video from the moment its first frame came out of the encoder.
+   * Everything in between — opening the camera, warming up GL — turned into a fixed offset with audio
+   * behind the picture. On a Samsung SM-A065F that offset measured 470 ms (18 clap pairs, 427-517 ms),
+   * plainly visible as lips moving before the sound. It is the same in both TimestampMode branches,
+   * which is why switching modes never helped.
+   *
+   * Falls back to the old behaviour when the encoder was started without a shared origin.
+   */
+  private long rebaseSurfacePts(long ptsUs) {
+    if (presentTimeUs > 0) return Math.max(0, ptsUs - presentTimeUs);
+    if (firstTimestamp == 0) firstTimestamp = ptsUs;
+    return Math.max(0, ptsUs - firstTimestamp);
+  }
+
   @Override
   protected boolean checkBuffer(@NonNull ByteBuffer byteBuffer, @NonNull MediaCodec.BufferInfo bufferInfo) {
     if (forceKey && Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
@@ -510,12 +534,10 @@ public class VideoEncoder extends BaseEncoder implements GetCameraData {
         // Buffer mode: synthesize PTS from wall clock.
         bufferInfo.presentationTimeUs = TimeUtils.getCurrentTimeMicro() - presentTimeUs;
       } else {
-        // Surface mode: EGL timestamp is camera sensor time (nanoseconds from boot ÷ 1000).
-        // It has clean, jitter-free intervals — but it's a huge absolute value that breaks RTMP.
-        // Rebase to relative by subtracting the first frame's PTS → clean intervals, starts at 0.
-        if (firstTimestamp == 0) firstTimestamp = bufferInfo.presentationTimeUs;
-        bufferInfo.presentationTimeUs -= firstTimestamp;
+        bufferInfo.presentationTimeUs = rebaseSurfacePts(bufferInfo.presentationTimeUs);
       }
+    } else if (formatVideoEncoder == FormatVideoEncoder.SURFACE) {
+      bufferInfo.presentationTimeUs = rebaseSurfacePts(bufferInfo.presentationTimeUs);
     } else {
       if (firstTimestamp == 0) firstTimestamp = bufferInfo.presentationTimeUs;
       bufferInfo.presentationTimeUs -= firstTimestamp;


### PR DESCRIPTION
In SURFACE mode `VideoEncoder.checkBuffer` rebases every frame on `firstTimestamp` — the PTS of the first frame this encoder produced. `AudioEncoder.calculatePts` rebases on `presentTimeUs`, the origin `StreamBase` hands to every encoder in `startSources()`.

The two timelines therefore start at different moments: audio at the instant the stream started, video at the instant its first frame came out of the encoder. Whatever sits between them — opening the camera, warming up GL — becomes a constant offset, with the picture running ahead of the sound.

### Measurement

Samsung SM-A065F, Android 15, camera source, built-in mic, RTMP to a local `ffmpeg -listen 1` sink over an `adb reverse` tunnel. Method: clap into the camera, find the transient in the audio and the burst of motion in the video, compare.

| build | offset |
|---|---|
| 2.7.2 | video 436-540 ms ahead of audio |
| 2.7.5 | video 470 ms ahead (18 clap pairs, spread 427-517 ms) |
| 2.7.5 + this fix | 490 ms cluster gone; residual within the resolution of a clap test |

It is plainly visible as lips moving before the sound is heard, which is how the users reported it.

Both `TimestampMode` branches perform the same rebase, so switching CLOCK/BUFFER changes nothing — I measured both and got the same figure. Worth noting because the container metadata is misleading here: with CLOCK the track `start_time` values look perfectly aligned while the actual A/V correspondence is still off by the same 470 ms.

### Why rebasing on `presentTimeUs` is safe

`GlStreamInterface` stamps frames through `GlTimestamp`, which anchors the first frame to `TimeUtils.getCurrentTimeNano()` and clamps later frames to within one frame of that clock. `StreamBase.startSources()` reads the same `TimeUtils` to start the encoders. Both sides are CLOCK_BOOTTIME microseconds, so the subtraction is meaningful and mirrors what the audio path already does.

### Scope

Only the SURFACE path changes. The buffer path keeps synthesizing from the wall clock, the non-surface BUFFER path keeps its own rebase, and if an encoder is ever started without a shared origin the helper falls back to the previous behaviour.

Happy to adjust the approach if you would rather solve it elsewhere — for instance by resetting `firstTimestamp` from `startSources()` — the important part is that the two encoders stop counting from different zeros.