### PR TITLE
Announce the rotated resolution so portrait streams are not pillarboxed

### DIFF
--- a/library/src/main/java/com/pedro/library/base/StreamBase.kt
+++ b/library/src/main/java/com/pedro/library/base/StreamBase.kt
@@ -503,7 +503,11 @@ abstract class StreamBase(
     return glInterface.surfaceTexture
   }
 
-  protected fun getVideoResolution() = Size(videoEncoder.width, videoEncoder.height)
+  protected fun getVideoResolution(): Size {
+    val portrait = videoEncoder.rotation == 90 || videoEncoder.rotation == 270
+    return if (portrait) Size(videoEncoder.height, videoEncoder.width)
+    else Size(videoEncoder.width, videoEncoder.height)
+  }
 
   protected fun getVideoFps() = videoEncoder.fps
 


### PR DESCRIPTION
A portrait broadcast tells the RTMP server it is landscape.

`VideoEncoder` stores `width`/`height` exactly as `prepareVideoEncoder` received them and keeps `rotation` separately — at 90 or 270 it configures the codec as `height x width` (VideoEncoder.java:136-141). So a stream prepared with `(1920, 1080, rotation = 90)` really produces 1080x1920 frames, while `getVideoResolution()` returns 1920x1080.

That pair goes straight into `onMetaData`:

- `GenericStream.kt:111`
- `RtmpStream.kt:73`
- `MultiStream.kt:188`

Players trust `onMetaData`. YouTube opens a 16:9 window and pillarboxes the vertical picture — black bars down both sides — which is exactly what our users reported for vertical streams.

`MultiCamera1/2` already handle this at the call site:

```kotlin
if (videoEncoder.rotation == 90 || videoEncoder.rotation == 270) {
    rtmpClients[index].setVideoResolution(videoEncoder.height, videoEncoder.width)
} else {
    rtmpClients[index].setVideoResolution(videoEncoder.width, videoEncoder.height)
}
```

so only the newer classes are affected. I fixed it inside `getVideoResolution()` instead of repeating the swap three times, so anything else reading it also gets the shape that is actually on the wire.

Measured on a Samsung SM-A065F, camera in portrait: prepared 1920x1080 with rotation 90, captured stream carries 1080x1920 frames (read from the SPS), and the announced resolution now matches instead of claiming landscape.