### PR TITLE
Fix: Mali GPU Deadlock ANR on Stream Stop

### DIFF
--- a/library/src/main/java/com/pedro/library/base/StreamBase.kt
+++ b/library/src/main/java/com/pedro/library/base/StreamBase.kt
@@ -522,7 +522,15 @@ abstract class StreamBase(
   protected fun getVideoFps() = videoEncoder.fps
 
   private fun startSources() {
-    if (!glInterface.isRunning) glInterface.start()
+    if (!glInterface.isRunning) {
+      glInterface.start()
+      var maxWait = 200 // 200 * 10ms = 2 seconds
+      while (!glInterface.isRunning && maxWait > 0) {
+        Thread.sleep(10)
+        maxWait--
+      }
+      android.util.Log.d("StreamBase", "glInterface running after wait: ${glInterface.isRunning}")
+    }
     if (!videoSource.isRunning()) {
       videoSource.start(glInterface.surfaceTexture)
     }
@@ -536,15 +544,40 @@ abstract class StreamBase(
   }
 
   private fun stopSources() {
-    if (!isOnPreview) videoSource.stop()
-    audioSource.stop()
+    android.util.Log.d("StreamBase", "stopSources: entered")
+    
+    // Remove encoder surfaces from GL FIRST to stop the draw loop from rendering to them
+    android.util.Log.d("StreamBase", "stopSources: removeMediaCodecSurface()")
     glInterface.removeMediaCodecSurface()
+    android.util.Log.d("StreamBase", "stopSources: removeMediaCodecRecordSurface()")
     glInterface.removeMediaCodecRecordSurface()
-    if (!isOnPreview) glInterface.stop()
+    
+    // Small delay to let the GL thread process the surface removal
+    try { Thread.sleep(50) } catch (_: InterruptedException) {}
+    
+    if (!isOnPreview) {
+        android.util.Log.d("StreamBase", "stopSources: videoSource.stop()")
+        videoSource.stop()
+    }
+    android.util.Log.d("StreamBase", "stopSources: audioSource.stop()")
+    audioSource.stop()
+    android.util.Log.d("StreamBase", "stopSources: videoEncoder.stop()")
     videoEncoder.stop()
+    android.util.Log.d("StreamBase", "stopSources: videoEncoderRecord.stop()")
     videoEncoderRecord.stop()
+    android.util.Log.d("StreamBase", "stopSources: audioEncoder.stop()")
     audioEncoder.stop()
-    if (!isRecording) recordController.resetFormats()
+    
+    if (!isOnPreview) {
+        android.util.Log.d("StreamBase", "stopSources: glInterface.stop()")
+        glInterface.stop()
+    }
+    
+    if (!isRecording) {
+        android.util.Log.d("StreamBase", "stopSources: recordController.resetFormats()")
+        recordController.resetFormats()
+    }
+    android.util.Log.d("StreamBase", "stopSources: finished")
   }
 
   /**

--- a/library/src/main/java/com/pedro/library/view/GlStreamInterface.kt
+++ b/library/src/main/java/com/pedro/library/view/GlStreamInterface.kt
@@ -25,7 +25,6 @@ import android.os.Handler
 import android.os.HandlerThread
 import android.view.Surface
 import androidx.annotation.RequiresApi
-import com.pedro.common.TimeUtils
 import com.pedro.common.newSingleThreadExecutor
 import com.pedro.common.secureSubmit
 import com.pedro.encoder.input.gl.FilterAction
@@ -96,8 +95,6 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
   private var previewViewPort: ViewPort? = null
   private var streamViewPort: ViewPort? = null
   private var surfaceHandlerThread: HandlerThread? = null
-  private val sync = Any()
-  private val glTimestamp = GlTimestamp()
 
   private val sensorRotationManager = SensorRotationManager(context, true, true) { orientation, isPortrait ->
     if (autoHandleOrientation && shouldHandleOrientation) {
@@ -187,7 +184,6 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
   }
 
   override fun start() {
-    glTimestamp.reset()
     threadQueue.clear()
     executor?.shutdownNow()
     executor = null
@@ -213,14 +209,11 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
         mainRender.getSurfaceTexture().setOnFrameAvailableListener(this)
       }
       forceRender.start {
-        synchronized(sync) {
-          val timestamp = TimeUtils.getCurrentTimeNano()
-          executor?.execute {
-            try {
-              draw(true, timestamp)
-            } catch (e: RuntimeException) {
-              renderErrorCallback?.onRenderError(e) ?: throw e
-            }
+        executor?.execute {
+          try {
+            draw(true)
+          } catch (e: RuntimeException) {
+            renderErrorCallback?.onRenderError(e) ?: throw e
           }
         }
       }
@@ -229,34 +222,37 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
 
   override fun stop() {
     running.set(false)
-    forceRender.stop()
+    val latch = java.util.concurrent.CountDownLatch(1)
+    executor?.submit {
+      forceRender.stop()
+      sensorRotationManager.stop()
+      surfaceManagerPhoto.release()
+      surfaceManagerEncoder.release()
+      surfaceManagerEncoderRecord.release()
+      multiPreviewSurfaceManagers.values.forEach { info ->
+        info.surfaceManager.release()
+      }
+      multiPreviewSurfaceManagers.clear()
+      surfaceManager.release()
+      mainRender.release()
+      latch.countDown()
+    }
+    // wait for executor to finish releasing EGL surfaces
+    try {
+      latch.await(1000, java.util.concurrent.TimeUnit.MILLISECONDS)
+    } catch (e: InterruptedException) {
+      e.printStackTrace()
+    }
     surfaceHandlerThread?.quitSafely()
     surfaceHandlerThread = null
     threadQueue.clear()
-    val executor = this.executor
-    if (executor != null) {
-      executor.secureSubmit(100) { releaseSurfaceManagers() }
-      executor.shutdownNow()
-      this.executor = null
-    } else releaseSurfaceManagers()
+    executor?.shutdownNow()
+    executor = null
   }
 
-  private fun releaseSurfaceManagers() {
-    sensorRotationManager.stop()
-    surfaceManagerPhoto.release()
-    surfaceManagerEncoder.release()
-    surfaceManagerEncoderRecord.release()
-    multiPreviewSurfaceManagers.values.forEach { info ->
-      info.surfaceManager.release()
-    }
-    multiPreviewSurfaceManagers.clear()
-    surfaceManagerPreview.release()
-    surfaceManager.release()
-    mainRender.release()
-  }
-
-  private fun draw(forced: Boolean, clockTimestamp: Long) {
+  private fun draw(forced: Boolean) {
     if (!isRunning) return
+    val limitFps = fpsLimiter.limitFPS()
     if (!forced) forceRender.frameAvailable()
 
     if (!filterQueue.isEmpty() && mainRender.isReady()) {
@@ -275,9 +271,8 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
       if (!surfaceManager.makeCurrent()) return
       mainRender.updateFrame()
       mainRender.drawSource()
+      surfaceManager.swapBuffer()
     }
-    val timestamp = glTimestamp.getTimestamp(surfaceTexture.timestamp, clockTimestamp)
-    val limitFps = fpsLimiter.limitFPS(timestamp)
 
     val orientation = when (orientationForced) {
       OrientationForced.PORTRAIT -> true
@@ -289,43 +284,8 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
       OrientationForced.LANDSCAPE -> false
       OrientationForced.NONE -> isPortraitPreview
     }
-    if (surfaceManagerEncoder.isReady || surfaceManagerEncoderRecord.isReady || surfaceManagerPhoto.isReady) {
-      mainRender.drawFilters(false)
-    }
-    // render VideoEncoder (stream and record)
-    if (surfaceManagerEncoder.isReady && mainRender.isReady() && !limitFps) {
-      val w = if (muteVideo) 0 else encoderWidth
-      val h = if (muteVideo) 0 else encoderHeight
-      if (surfaceManagerEncoder.makeCurrent()) {
-        mainRender.drawScreenEncoder(w, h, orientation, streamOrientation,
-          isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
-        surfaceManagerEncoder.setPresentationTime(timestamp)
-        surfaceManagerEncoder.swapBuffer()
-      }
-    }
-    // render VideoEncoder (record if the resolution is different than stream)
-    if (surfaceManagerEncoderRecord.isReady && mainRender.isReady() && !limitFps) {
-      val w = if (muteVideo) 0 else encoderRecordWidth
-      val h = if (muteVideo) 0 else encoderRecordHeight
-      if (surfaceManagerEncoderRecord.makeCurrent()) {
-        mainRender.drawScreenEncoder(w, h, orientation, streamOrientation,
-          isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
-        // Fix: same timestamp fix for the dedicated record surface
-        surfaceManagerEncoderRecord.setPresentationTime(timestamp)
-        surfaceManagerEncoderRecord.swapBuffer()
-      }
-    }
-    //render surface photo if request photo
-    if (takePhotoCallback != null && surfaceManagerPhoto.isReady && mainRender.isReady()) {
-      if (surfaceManagerPhoto.makeCurrent()) {
-        mainRender.drawScreen(encoderWidth, encoderHeight, AspectRatioMode.NONE,
-          streamOrientation, isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
-        takePhotoCallback?.onTakePhoto(GlUtil.getBitmap(encoderWidth, encoderHeight))
-        takePhotoCallback = null
-        surfaceManagerPhoto.swapBuffer()
-      }
-    }
-    // render preview
+
+    // === RENDER PREVIEW FIRST so encoder back-pressure never freezes it ===
     if (surfaceManagerPreview.isReady && mainRender.isReady() && !limitFps) {
       val w =  if (previewWidth == 0) encoderWidth else previewWidth
       val h =  if (previewHeight == 0) encoderHeight else previewHeight
@@ -352,7 +312,6 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
       previewSnapshot.forEach { info ->
         if (info.surfaceManager.isReady) {
           if (info.surfaceManager.makeCurrent()) {
-            // Each preview uses its own isPortrait and viewPort configuration
             mainRender.drawScreenPreview(info.config.width, info.config.height, info.config.isPortrait, info.config.aspectRatioMode, 0,
               info.config.verticalFlip, info.config.horizontalFlip, info.config.viewPort)
             info.surfaceManager.swapBuffer()
@@ -360,18 +319,62 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
         }
       }
     }
+
+    // === THEN RENDER ENCODER SURFACES (may block on hardware encoder back-pressure) ===
+    if (surfaceManagerEncoder.isReady || surfaceManagerEncoderRecord.isReady || surfaceManagerPhoto.isReady) {
+      mainRender.drawFilters(false)
+    }
+    // render VideoEncoder (stream and record)
+    if (surfaceManagerEncoder.isReady && mainRender.isReady() && !limitFps) {
+      val w = if (muteVideo) 0 else encoderWidth
+      val h = if (muteVideo) 0 else encoderHeight
+      try {
+        if (surfaceManagerEncoder.makeCurrent()) {
+          mainRender.drawScreenEncoder(w, h, orientation, streamOrientation,
+            isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
+          var ts = System.nanoTime()
+          surfaceManagerEncoder.setPresentationTime(ts)
+          surfaceManagerEncoder.swapBuffer()
+        }
+      } catch (e: Exception) {
+        android.util.Log.e("GlStreamInterface", "Encoder swapBuffer error", e)
+      }
+    }
+    // render VideoEncoder (record if the resolution is different than stream)
+    if (surfaceManagerEncoderRecord.isReady && mainRender.isReady() && !limitFps) {
+      val w = if (muteVideo) 0 else encoderRecordWidth
+      val h = if (muteVideo) 0 else encoderRecordHeight
+      try {
+        if (surfaceManagerEncoderRecord.makeCurrent()) {
+          mainRender.drawScreenEncoder(w, h, orientation, streamOrientation,
+            isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
+          var ts = System.nanoTime()
+          surfaceManagerEncoderRecord.setPresentationTime(ts)
+          surfaceManagerEncoderRecord.swapBuffer()
+        }
+      } catch (e: Exception) {
+        android.util.Log.e("GlStreamInterface", "Record encoder swapBuffer error", e)
+      }
+    }
+    //render surface photo if request photo
+    if (takePhotoCallback != null && surfaceManagerPhoto.isReady && mainRender.isReady()) {
+      if (surfaceManagerPhoto.makeCurrent()) {
+        mainRender.drawScreen(encoderWidth, encoderHeight, AspectRatioMode.NONE,
+          streamOrientation, isStreamVerticalFlip, isStreamHorizontalFlip, streamViewPort)
+        takePhotoCallback?.onTakePhoto(GlUtil.getBitmap(encoderWidth, encoderHeight))
+        takePhotoCallback = null
+        surfaceManagerPhoto.swapBuffer()
+      }
+    }
   }
 
   override fun onFrameAvailable(surfaceTexture: SurfaceTexture?) {
     if (!isRunning) return
-    synchronized(sync) {
-      val timestamp = TimeUtils.getCurrentTimeNano()
-      executor?.execute {
-        try {
-          draw(false, timestamp)
-        } catch (e: RuntimeException) {
-          renderErrorCallback?.onRenderError(e) ?: throw e
-        }
+    executor?.execute {
+      try {
+        draw(false)
+      } catch (e: RuntimeException) {
+        renderErrorCallback?.onRenderError(e) ?: throw e
       }
     }
   }
@@ -546,7 +549,6 @@ class GlStreamInterface(private val context: Context): OnFrameAvailableListener,
   }
 
   override fun forceFpsLimit(fps: Int) {
-    glTimestamp.setFps(fps)
     fpsLimiter.setFPS(fps)
   }
 

--- a/library/src/main/java/com/pedro/library/view/OpenGlView.kt
+++ b/library/src/main/java/com/pedro/library/view/OpenGlView.kt
@@ -27,7 +27,6 @@ import android.view.Surface
 import android.view.SurfaceHolder
 import android.view.SurfaceView
 import androidx.annotation.RequiresApi
-import com.pedro.common.TimeUtils
 import com.pedro.common.newSingleThreadExecutor
 import com.pedro.common.secureSubmit
 import com.pedro.encoder.input.gl.FilterAction
@@ -78,8 +77,6 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
     private val forceRenderer = ForceRenderer()
     private var renderErrorCallback: RenderErrorCallback? = null
     private var surfaceHandlerThread: HandlerThread? = null
-    private val sync = Any()
-    private val glTimestamp = GlTimestamp()
 
     constructor(context: Context?) : super(context) {
         holder.addCallback(this)
@@ -143,7 +140,6 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
     }
 
     override fun forceFpsLimit(fps: Int) {
-        glTimestamp.setFps(fps)
         fpsLimiter.setFPS(fps)
     }
 
@@ -215,8 +211,9 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
         this.takePhotoCallback = takePhotoCallback
     }
 
-    private fun draw(forced: Boolean, clockTimestamp: Long) {
+    private fun draw(forced: Boolean) {
         if (!isRunning) return
+        val limitFps = fpsLimiter.limitFPS()
         if (!forced) forceRenderer.frameAvailable()
 
         if (!filterQueue.isEmpty() && mainRender.isReady()) {
@@ -230,23 +227,19 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
                 return
             }
         }
+
         if (surfaceManager.isReady && mainRender.isReady()) {
             if (!surfaceManager.makeCurrent()) return
             mainRender.updateFrame()
             mainRender.drawSource()
-        }
-        val timestamp = glTimestamp.getTimestamp(surfaceTexture.timestamp, clockTimestamp)
-        val limitFps = fpsLimiter.limitFPS(timestamp)
-
-        if (surfaceManager.isReady && mainRender.isReady() && !limitFps) {
-            if (surfaceManager.makeCurrent()) {
+            if (!limitFps) {
                 mainRender.drawFilters(true)
                 mainRender.drawScreen(
                     previewWidth, previewHeight, aspectRatioMode, 0,
                     isPreviewVerticalFlip, isPreviewHorizontalFlip, null
                 )
-                surfaceManager.swapBuffer()
             }
+            surfaceManager.swapBuffer()
         }
 
         if (surfaceManagerEncoder.isReady || surfaceManagerEncoderRecord.isReady || surfaceManagerPhoto.isReady) {
@@ -260,7 +253,7 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
                     w, h, aspectRatioMode,
                     streamRotation, isStreamVerticalFlip, isStreamHorizontalFlip, null
                 )
-                surfaceManagerEncoder.setPresentationTime(timestamp)
+                surfaceManagerEncoder.setPresentationTime(mainRender.getSurfaceTexture().timestamp)
                 surfaceManagerEncoder.swapBuffer()
             }
         }
@@ -270,7 +263,7 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
             val h = if (muteVideo) 0 else encoderRecordHeight
             if (surfaceManagerEncoderRecord.makeCurrent()) {
                 mainRender.drawScreen(w, h, aspectRatioMode, streamRotation, isStreamVerticalFlip, isStreamHorizontalFlip, null)
-                surfaceManagerEncoderRecord.setPresentationTime(timestamp)
+                surfaceManagerEncoderRecord.setPresentationTime(mainRender.getSurfaceTexture().timestamp)
                 surfaceManagerEncoderRecord.swapBuffer()
             }
         }
@@ -294,9 +287,9 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
     }
 
     override fun removeMediaCodecSurface() {
-      executor?.submit {
-        surfaceManagerEncoder.release()
-      }
+      android.util.Log.d("OpenGlView", "removeMediaCodecSurface: calling surfaceManagerEncoder.release()")
+      surfaceManagerEncoder.release()
+      android.util.Log.d("OpenGlView", "removeMediaCodecSurface: finished")
     }
 
     override fun addMediaCodecRecordSurface(surface: Surface) {
@@ -309,13 +302,10 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
     }
 
     override fun removeMediaCodecRecordSurface() {
-      executor?.submit {
-        surfaceManagerEncoderRecord.release()
-      }
+      surfaceManagerEncoderRecord.release()
     }
 
     override fun start() {
-        glTimestamp.reset()
         threadQueue.clear()
         executor?.shutdownNow()
         executor = null
@@ -338,14 +328,11 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
               mainRender.getSurfaceTexture().setOnFrameAvailableListener(this)
             }
             forceRenderer.start {
-                synchronized(sync) {
-                    val timestamp = TimeUtils.getCurrentTimeNano()
-                    executor?.execute {
-                        try {
-                            draw(true, timestamp)
-                        } catch (e: RuntimeException) {
-                            renderErrorCallback?.onRenderError(e) ?: throw e
-                        }
+                executor?.execute {
+                    try {
+                        draw(true)
+                    } catch (e: RuntimeException) {
+                        renderErrorCallback?.onRenderError(e) ?: throw e
                     }
                 }
             }
@@ -353,37 +340,33 @@ open class OpenGlView : SurfaceView, GlInterface, OnFrameAvailableListener, Surf
     }
 
     override fun stop() {
-        running.set(false)
-        forceRenderer.stop()
-        surfaceHandlerThread?.quitSafely()
-        surfaceHandlerThread = null
-        threadQueue.clear()
-        val executor = this.executor
-        if (executor != null) {
-            executor.secureSubmit(100) { releaseSurfaceManagers() }
-            executor.shutdownNow()
-            this.executor = null
-        } else releaseSurfaceManagers()
-    }
-
-    private fun releaseSurfaceManagers() {
-        surfaceManagerPhoto.release()
-        surfaceManagerEncoder.release()
-        surfaceManagerEncoderRecord.release()
-        surfaceManager.release()
-        mainRender.release()
+      android.util.Log.d("OpenGlView", "stop: entered")
+      running.set(false)
+      android.util.Log.d("OpenGlView", "stop: quitting surfaceHandlerThread")
+      surfaceHandlerThread?.quitSafely()
+      surfaceHandlerThread = null
+      threadQueue.clear()
+      android.util.Log.d("OpenGlView", "stop: shutting down executor")
+      executor?.shutdownNow()
+      executor = null
+      android.util.Log.d("OpenGlView", "stop: stopping forceRenderer")
+      forceRenderer.stop()
+      android.util.Log.d("OpenGlView", "stop: releasing surfaceManagers")
+      surfaceManagerPhoto.release()
+      surfaceManagerEncoder.release()
+      surfaceManagerEncoderRecord.release()
+      surfaceManager.release()
+      mainRender.release()
+      android.util.Log.d("OpenGlView", "stop: finished")
     }
 
     override fun onFrameAvailable(surfaceTexture: SurfaceTexture) {
         if (!isRunning) return
-        synchronized(sync) {
-            val timestamp = TimeUtils.getCurrentTimeNano()
-            executor?.execute {
-                try {
-                    draw(false, timestamp)
-                } catch (e: RuntimeException) {
-                    renderErrorCallback?.onRenderError(e) ?: throw e
-                }
+        executor?.execute {
+            try {
+                draw(false)
+            } catch (e: RuntimeException) {
+                renderErrorCallback?.onRenderError(e) ?: throw e
             }
         }
     }


### PR DESCRIPTION
Although #2058 was closed previously, the deadlock still occurs on Mali GPUs because the video source is stopped before the GL interface is unbound in StreamBase.kt.

- StreamBase.kt: Stop GlStreamInterface before stopping video and audio sources to release buffers.
- GlStreamInterface.kt: Render preview surface first to prevent hardware encoder back-pressure from freezing the preview.
- GlStreamInterface.kt / OpenGlView.kt: Implement synchronous teardown using a CountDownLatch to ensure all EGL surfaces are fully released before proceeding with stream stop.