### PR TITLE
srt: optional server silence timeout to detect a dead path

### DIFF
--- a/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
+++ b/library/src/main/java/com/pedro/library/util/streamclient/SrtStreamClient.kt
@@ -73,6 +73,14 @@ class SrtStreamClient(
     srtClient.setLogs(enabled)
   }
 
+  /**
+   * Report a connection failure if the server sends nothing for [millis] (0 = disabled).
+   * See [com.pedro.srt.srt.SrtClient.setServerSilenceTimeout].
+   */
+  fun setServerSilenceTimeout(millis: Long) {
+    srtClient.setServerSilenceTimeout(millis)
+  }
+
   override fun setCheckServerAlive(enabled: Boolean) {
     srtClient.setCheckServerAlive(enabled)
   }

--- a/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
+++ b/srt/src/main/java/com/pedro/srt/srt/SrtClient.kt
@@ -24,6 +24,7 @@ import com.pedro.common.ConnectionFailed
 import com.pedro.common.UrlParser
 import com.pedro.common.VideoCodec
 import com.pedro.common.frame.MediaFrame
+import com.pedro.common.TimeUtils
 import com.pedro.common.onMainThread
 import com.pedro.common.socket.base.SocketType
 import com.pedro.common.socket.base.StreamSocket
@@ -80,6 +81,7 @@ class SrtClient(private val connectChecker: ConnectChecker) {
   private var jobRetry: Job? = null
 
   private var checkServerAlive = false
+  private var serverSilenceTimeoutMs = 0L
   @Volatile
   var isStreaming = false
     private set
@@ -167,6 +169,19 @@ class SrtClient(private val connectChecker: ConnectChecker) {
    */
   fun setCheckServerAlive(enabled: Boolean) {
     checkServerAlive = enabled
+  }
+
+  /**
+   * Report onConnectionFailed("No response from server") if no packet is received from the
+   * server for [millis]. While data is being published, the server acknowledges it with ACK
+   * packets (typically every 10 ms), so a long silence means the path is dead even if sending
+   * does not fail (for example, packets silently dropped by the network).
+   * Unlike [setCheckServerAlive] it needs no ICMP/Echo, which firewalls often block.
+   * Servers only acknowledge received data, so use a value well above the longest pause in
+   * which no media is sent. 0 (default) disables the check.
+   */
+  fun setServerSilenceTimeout(millis: Long) {
+    serverSilenceTimeoutMs = millis
   }
 
   fun setReTries(reTries: Int) {
@@ -333,11 +348,13 @@ class SrtClient(private val connectChecker: ConnectChecker) {
 
   @Throws(IOException::class)
   private suspend fun handleServerPackets() {
+    var lastServerPacketTs = TimeUtils.getCurrentTimeMillis()
     while (scope.isActive && isStreaming) {
       val error = runCatching {
         if (isAlive()) {
           //ignore packet after connect if tunneled to avoid spam idle
           handleMessages()
+          lastServerPacketTs = TimeUtils.getCurrentTimeMillis()
         } else {
           onMainThread {
             connectChecker.onConnectionFailed("No response from server")
@@ -346,6 +363,12 @@ class SrtClient(private val connectChecker: ConnectChecker) {
         }
       }.exceptionOrNull()
       if (error != null && ConnectionFailed.parse(error.validMessage()) != ConnectionFailed.TIMEOUT) {
+        scope.cancel()
+      } else if (error != null && serverSilenceTimeoutMs > 0 &&
+        TimeUtils.getCurrentTimeMillis() - lastServerPacketTs >= serverSilenceTimeoutMs) {
+        onMainThread {
+          connectChecker.onConnectionFailed("No response from server")
+        }
         scope.cancel()
       }
     }


### PR DESCRIPTION
## SRT: optional server silence timeout

### Motivation
When the network path dies silently, the SRT client keeps sending and never reports a failure. Examples: a tunnel, a dead zone where the interface stays up, NAT rebinding, or UDP silently dropped by a middlebox. UDP `send` does not fail, `SrtSender` does not wait for ACKs, and `handleServerPackets` treats every `SocketTimeoutException` as `ConnectionFailed.TIMEOUT`. The app therefore streams into the void until the server-side session is dropped. We measured more than 60 s with MediaMTX.

`setCheckServerAlive(true)` does not help in our setup. It relies on `isReachable()` (ICMP/Echo), which is blocked by most cloud firewalls (e.g. Azure), so it reports healthy connections as dead.

### Change
- New opt-in `SrtClient.setServerSilenceTimeout(millis)`, exposed as `SrtStreamClient.setServerSilenceTimeout(millis)`. The default is `0`, which disables it, so existing behavior does not change.
- `handleServerPackets` remembers when the last packet (ACK, keepalive, NAK, …) arrived from the server. If a read times out and nothing has been received for at least `millis`, it reports `onConnectionFailed("No response from server")` and cancels the scope. That is the same path the existing `checkServerAlive` branch uses, so `reTry` works as usual.
- While data is being published, the server acknowledges it with ACK packets (MediaMTX: about every 10 ms). A silence of several seconds is therefore a reliable signal that the path is dead. Servers only acknowledge received data, so the timeout should be well above the longest pause in which no media is sent. Because of the 5 s socket read timeout, detection happens between `millis` and `millis + 5 s`.

### Testing
Android emulator publishing to MediaMTX 1.18.2 over SRT. `docker pause` on the MediaMTX container for 60 s simulates a silent dead path (no reply, no ICMP).

| | without the timeout | with `setServerSilenceTimeout(10_000)` |
|---|---|---|
| While paused | nothing is reported for the whole pause | `onConnectionFailed("No response from server")` 11 s after the pause started; `reTry` then attempts roughly every 7 s (handshake timeout) |
| After resume | the failure only surfaces now ("Shutdown received from server") | reconnected about 1 s after the container was resumed |

- **No false positives:** the timeout fired exactly once in the run. It did not fire while streaming normally before the pause, or during the 60 s after reconnecting.
- **No unit test:** `handleServerPackets` is private and the client creates its socket internally, so a unit test would need a socket-injection refactor. Verified end-to-end instead.
