### PR TITLE
keep encoders running in stopStream while a recording is starting or paused

### DIFF
--- a/library/src/main/java/com/pedro/library/base/Camera1Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera1Base.java
@@ -766,7 +766,7 @@ public abstract class Camera1Base {
       streaming = false;
       stopStreamImp();
     }
-    if (!recordController.isRecording()) {
+    if (!recordController.isRunning()) {
       if (audioInitialized) microphoneManager.stop();
       if (glInterface != null && Build.VERSION.SDK_INT >= 18) {
         glInterface.removeMediaCodecSurface();

--- a/library/src/main/java/com/pedro/library/base/Camera2Base.java
+++ b/library/src/main/java/com/pedro/library/base/Camera2Base.java
@@ -776,7 +776,7 @@ public abstract class Camera2Base {
             streaming = false;
             stopStreamImp();
         }
-        if (!recordController.isRecording()) {
+        if (!recordController.isRunning()) {
             onPreview = !isBackground;
             if (audioInitialized) microphoneManager.stop();
             glInterface.removeMediaCodecSurface();

--- a/library/src/main/java/com/pedro/library/base/DisplayBase.java
+++ b/library/src/main/java/com/pedro/library/base/DisplayBase.java
@@ -430,7 +430,7 @@ public abstract class DisplayBase {
       streaming = false;
       stopStreamImp();
     }
-    if (!recordController.isRecording()) {
+    if (!recordController.isRunning()) {
       if (audioInitialized) microphoneManager.stop();
       if (mediaProjection != null) {
         mediaProjection.stop();

--- a/library/src/main/java/com/pedro/library/base/FromFileBase.java
+++ b/library/src/main/java/com/pedro/library/base/FromFileBase.java
@@ -483,7 +483,7 @@ public abstract class FromFileBase {
       streaming = false;
       stopStreamImp();
     }
-    if (!recordController.isRecording()) {
+    if (!recordController.isRunning()) {
       if (glInterface != null) {
         glInterface.removeMediaCodecSurface();
         glInterface.stop();

--- a/library/src/main/java/com/pedro/library/base/OnlyAudioBase.java
+++ b/library/src/main/java/com/pedro/library/base/OnlyAudioBase.java
@@ -208,7 +208,7 @@ public abstract class OnlyAudioBase {
       streaming = false;
       stopStreamImp();
     }
-    if (!recordController.isRecording()) {
+    if (!recordController.isRunning()) {
       microphoneManager.stop();
       audioEncoder.stop();
       recordController.resetFormats();


### PR DESCRIPTION
## Keep encoders running in stopStream() while a recording is starting or paused

### Problem

`startStream()` and `stopStream()` check different record states:

- `startStream()` starts the encoders only if `!recordController.isRunning()`. Otherwise it just requests a keyframe.
- `stopStream()` stops encoders, microphone, GL surfaces and camera if `!recordController.isRecording()`.

`isRecording()` is only true in `RECORDING`. `isRunning()` is also true in `STARTED`, `PAUSED` and `RESUMED`. After `startRecord()` the controller stays in `STARTED` until the first keyframe arrives, usually 35–150 ms and up to one keyframe interval.

If `stopStream()` is called in that window (for example because the connection failed right after a new recording segment was started):

1. `isRecording()` is false, so the encoders, mic and camera are stopped and the formats are reset.
2. The record controller stays in `STARTED` and never receives a frame.
3. The next `startStream()` sees `isRunning() == true` and skips `startEncoders()`. `requestKeyFrame()` is a no-op because the encoder is not running.
4. Result: the stream connects but sends no media. The recording file stays empty, and every later `startRecord()` while streaming also gets no frames, because `startRecord()` only starts the encoders when not streaming.

The same applies to `PAUSED`: `stopStream()` during a paused recording stops the encoders, although `resumeRecord()` waits for the next keyframe.

`StreamBase.kt` already does this consistently: its `isRecording` property maps to `recordController.isRunning()`, and `stopStream()` uses it. `Camera2Base.isRecording()` also returns `isRunning()`.

### Fix

`stopStream()` now checks `!recordController.isRunning()`, symmetric to `startStream()`, in all Java bases:

- `Camera1Base`
- `Camera2Base`
- `DisplayBase`
- `FromFileBase`
- `OnlyAudioBase`

With this change, stopping the stream while a recording is starting or paused keeps the encoders alive, which is the same behaviour as today while `RECORDING`.

`stopRecord()` still cleans up correctly. `recordController.stopRecord()` sets the status to `STOPPED` before `if (!streaming) stopStream()` runs, so the full teardown happens as before.

### Test

Android emulator, `SrtCamera2` streaming to MediaMTX, with a local recording rotated every 60 s while streaming (`stopRecord()` + `startRecord(newFile)`). A debug hook called `stopStream()` directly after `startRecord()` of a new segment, while the status was still `STARTED`.

| | before | after |
|---|---|---|
| Encoders after `stopStream()` | stopped 0.2 s later | keep running, keyframe requests are served |
| New recording segment | 0 bytes | ~93 KB (recorded until the app restarted the session) |

Normal reconnects (library `reTry` and a full stop/start) behave as before.
